### PR TITLE
OPS-144: Consistency for release notes between EDNAR and non-EDNAR changelogs

### DIFF
--- a/pipelines/basic/scripts/update-version.sh
+++ b/pipelines/basic/scripts/update-version.sh
@@ -73,15 +73,15 @@ else
 fi
 
 # Update changelog
-release_notes_template="##### Breaking Changes\n* None.\n\n##### New Features\n* None.\n\n##### Enhancements\n* None.\n\n##### Fixes\n* None.\n\n##### Notes\n* None.\n"
+release_notes_template="### Breaking Changes\n* None.\n\n### New Features\n* None.\n\n### Enhancements\n* None.\n\n### Fixes\n* None.\n\n### Notes\n* None.\n"
 if [[ ! -z $changelog ]]; then
     if [[ " ${options[@]} " =~ " --grow-changelog " ]]; then
         info "Inserting template into changelog..."
-        sed -i "/^# .*/a ### [${new_version/-SNAPSHOT*/}] - UNRELEASED\n$release_notes_template" $changelog
+        sed -i "/^# .*/a ## [${new_version/-SNAPSHOT*/}] - UNRELEASED\n$release_notes_template" $changelog
     else
         info "Resetting changelog to template..."
         rm -f $changelog && touch $changelog
-        printf "### v${new_version/-SNAPSHOT*/}\n\n$release_notes_template" >> $changelog
+        printf "## v${new_version/-SNAPSHOT*/}\n\n$release_notes_template" >> $changelog
     fi
 fi
 

--- a/pipelines/basic/scripts/update-version.sh
+++ b/pipelines/basic/scripts/update-version.sh
@@ -73,14 +73,15 @@ else
 fi
 
 # Update changelog
+release_notes_template="##### Breaking Changes\n* None.\n\n##### New Features\n* None.\n\n##### Enhancements\n* None.\n\n##### Fixes\n* None.\n\n##### Notes\n* None.\n"
 if [[ ! -z $changelog ]]; then
     if [[ " ${options[@]} " =~ " --grow-changelog " ]]; then
         info "Inserting template into changelog..."
-        sed -i "/^# .*/a ## [${new_version/-SNAPSHOT*/}] - UNRELEASED\n### Breaking Changes\n- None.\n\n### Added\n- None.\n\n### Changed\n- None.\n\n### Fixed\n- None.\n\n### Removed\n- None.\n\n### Notes\n- None.\n" $changelog
+        sed -i "/^# .*/a ### [${new_version/-SNAPSHOT*/}] - UNRELEASED\n$release_notes_template" $changelog
     else
         info "Resetting changelog to template..."
         rm -f $changelog && touch $changelog
-        printf "### v${new_version/-SNAPSHOT*/}\n\n##### Breaking Changes\n* None.\n\n##### New Features\n* None.\n\n##### Enhancements\n* None.\n\n##### Fixes\n* None.\n\n##### Notes\n* None." >> $changelog
+        printf "### v${new_version/-SNAPSHOT*/}\n\n$release_notes_template" >> $changelog
     fi
 fi
 


### PR DESCRIPTION
Signed-off-by: Marcus Koh <marcus.koh@zepben.com>

# Description

To make everyone's life easier, this PR will make the headings for release notes consistent between EDNAR and non-EDNAR style changelogs.

# Associated tasks:

- [x] Merge https://github.com/zepben/docusaurus-action/pull/2

# Checklist:

- [x] I have performed a self review of my own code.
- [x] I have added unit tests / updated existing tests for these changes.
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.
- [x] I have commented my code in hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have considered if this is a breaking change and have communicated it with other team members if so.
