### PR TITLE
Updates for debugging and simplification

### DIFF
--- a/pipelines/Java/scripts/maven.sh
+++ b/pipelines/Java/scripts/maven.sh
@@ -37,5 +37,6 @@ java_deploy(){
 java_write_new_version(){
     old_version=${1:? 'Old version is required.'}
     new_version=${2:? 'New version is required.'}
-    run xmlstarlet ed -P -L -N pom="http://maven.apache.org/POM/4.0.0" -u "/pom:project/pom:version" -v "$new_version" $file
+    xmlstarlet ed -P -L -N pom="http://maven.apache.org/POM/4.0.0" -u "/pom:project/pom:version" -v "$new_version" $file
+    echo "Finished updating new version $new_version"
 }

--- a/pipelines/scripts/common.sh
+++ b/pipelines/scripts/common.sh
@@ -4,6 +4,9 @@
 set -e
 set -o pipefail
 
+# debug messages always for now
+set -x
+
 
 gray="\\e[37m"
 blue="\\e[36m"


### PR DESCRIPTION
Signed-off-by: Alex Lourie <alex.lourie@zepben.com>

# Description

Updated common.sh to always use `set -x` to include error/debug messages.
Updated maven.sh in `java_write_new_version` to *not* use `run()` to execute `xmlstarlet` call.

- [x] I have performed a self review of my own code.
