### PR TITLE
Update the maven image to newer amazonlinux

### DIFF
--- a/pipelines/Java/amazoncorretto-config.json
+++ b/pipelines/Java/amazoncorretto-config.json
@@ -46,7 +46,7 @@
             {
                 "type": "docker-tag",
                 "repository": "zepben/pipeline-java",
-                "tags": ["4.3.1", "latest"]
+                "tags": ["4.4.0"]
             },
             {
                 "type": "docker-push",

--- a/pipelines/Java/amazoncorretto-config.json
+++ b/pipelines/Java/amazoncorretto-config.json
@@ -6,7 +6,7 @@
     "builders": [
         {
             "type": "docker",
-            "image": "maven:3.8.7-amazoncorretto-11",
+            "image": "maven:3.9.8-amazoncorretto-11-al2023",
             "commit": "true"
         }
     ],

--- a/pipelines/Python/config.json
+++ b/pipelines/Python/config.json
@@ -7,7 +7,7 @@
     "builders": [
         {
             "type": "docker",
-            "image": "python:3.7-slim",
+            "image": "python:3.9-slim",
             "commit": "true"
         }
     ],

--- a/pipelines/Python/config.json
+++ b/pipelines/Python/config.json
@@ -32,7 +32,7 @@
             {
                 "type": "docker-tag",
                 "repository": "zepben/pipeline-python",
-                "tags": ["0.3.0", "latest"]
+                "tags": ["0.4.0"]
             },
             {
                 "type": "docker-push",


### PR DESCRIPTION
# Description

GitHub is now forcing all actions to node20 execution; however, our containers do not have a sufficient version of glibc (specifically the maven builds).

This PR updates the base image of our container to Amazon Linux 2023 (the latest as of this moment), which includes newer glibc.

While at it, we update the python base image to 3.9.8 as it's the lowest supported version in docker registry.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
~- [] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~