### PR TITLE
Ops 219 replace base java container

### DIFF
--- a/.github/workflows/java-amazoncorretto.yml
+++ b/.github/workflows/java-amazoncorretto.yml
@@ -12,11 +12,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Packer Version
+        run: |
+          packer version
+
       - name: Create zepben/pipeline-java-amazoncorretto
         run: |
           apk add docker tar
           mkdir /build
           export PACKER_CONFIG_DIR=/build
           cd pipelines/Java/
+          packer init amazoncorretto-config.pkr.hcl
+          packer validate amazoncorretto-config.pkr.hcl
           packer build -on-error=abort -var dockerhub_user=$DOCKER_HUB_USER -var dockerhub_pw=$DOCKER_HUB_ACCESS_TOKEN amazoncorretto-config.pkr.hcl
         shell: bash

--- a/.github/workflows/java-amazoncorretto.yml
+++ b/.github/workflows/java-amazoncorretto.yml
@@ -5,18 +5,12 @@ on: workflow_dispatch
 jobs:
   build_java_amazoncorretto:
     runs-on: ubuntu-latest
-    container:  hashicorp/packer:1.9
+    container:  hashicorp/packer:1.11
     env:
       DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Cache maven deps
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: maven
+      - uses: actions/checkout@v4
 
       - name: Create zepben/pipeline-java-amazoncorretto
         run: |
@@ -24,5 +18,5 @@ jobs:
           mkdir /build
           export PACKER_CONFIG_DIR=/build
           cd pipelines/Java/
-          packer build -var dockerhub_user=$DOCKER_HUB_USER -var dockerhub_pw=$DOCKER_HUB_ACCESS_TOKEN amazoncorretto-config.json
+          packer build -on-error=abort -var dockerhub_user=$DOCKER_HUB_USER -var dockerhub_pw=$DOCKER_HUB_ACCESS_TOKEN amazoncorretto-config.pkr.hcl
         shell: bash

--- a/pipelines/Java/amazoncorretto-config.json
+++ b/pipelines/Java/amazoncorretto-config.json
@@ -6,7 +6,7 @@
     "builders": [
         {
             "type": "docker",
-            "image": "maven:3.9.8-amazoncorretto-11-al2023",
+            "image": "debian:bookworm-20240701-slim",
             "commit": "true"
         }
     ],

--- a/pipelines/Java/amazoncorretto-config.json
+++ b/pipelines/Java/amazoncorretto-config.json
@@ -46,7 +46,7 @@
             {
                 "type": "docker-tag",
                 "repository": "zepben/pipeline-java",
-                "tags": ["4.4.0"]
+                "tags": ["4.5.0"]
             },
             {
                 "type": "docker-push",

--- a/pipelines/Java/amazoncorretto-config.pkr.hcl
+++ b/pipelines/Java/amazoncorretto-config.pkr.hcl
@@ -8,11 +8,13 @@ packer {
 }
 
 variable "dockerhub_pw" {
-  type = string
+  type    = string
+  default = "${env("DOCKER_HUB_ACCESS_TOKEN")}"
 }
 
 variable "dockerhub_user" {
-  type = string
+  type    = string
+  default = "${env("DOCKER_HUB_USER")}"
 }
 
 source "docker" "image" {

--- a/pipelines/Java/amazoncorretto-config.pkr.hcl
+++ b/pipelines/Java/amazoncorretto-config.pkr.hcl
@@ -1,0 +1,68 @@
+packer {
+  required_plugins {
+    docker = {
+      source  = "github.com/hashicorp/docker"
+      version = "~> 1"
+    }
+  }
+}
+
+variable "dockerhub_pw" {
+  type = string
+}
+
+variable "dockerhub_user" {
+  type = string
+}
+
+source "docker" "image" {
+  commit = "true"
+  image  = "debian:bookworm-20240701-slim"
+}
+
+build {
+  sources = ["source.docker.image"]
+
+  provisioner "shell" {
+    scripts = ["amazoncorretto-install-dependencies.sh", "../init.sh", "init.sh"]
+  }
+
+  provisioner "file" {
+    destination = "/scripts"
+    source      = "../scripts/"
+  }
+
+  provisioner "file" {
+    destination = "/scripts"
+    source      = "../scripts-build/"
+  }
+
+  provisioner "file" {
+    destination = "/usr/share/maven/conf/settings.xml"
+    source      = "maven-settings.xml"
+  }
+
+  provisioner "file" {
+    destination = "/scripts"
+    source      = "./scripts/"
+  }
+
+  provisioner "file" {
+    destination = "/root/.aws/"
+    source      = "../basic/aws/"
+  }
+
+  post-processors {
+    post-processor "docker-tag" {
+      name       = "docker.tag"
+      repository = "zepben/pipeline-java"
+      tags       = ["4.5.0"]
+    }
+    post-processor "docker-push" {
+      name           = "docker.push"
+      login           = true
+      login_password = "${var.dockerhub_pw}"
+      login_username = "${var.dockerhub_user}"
+    }
+  }
+}

--- a/pipelines/Java/amazoncorretto-install-dependencies.sh
+++ b/pipelines/Java/amazoncorretto-install-dependencies.sh
@@ -1,12 +1,21 @@
-yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm # for downloading xmlstarlet
-yum install xmlstarlet -y
-yum install jq -y
-yum install zip gnupg python3 python3-pip git zip -y
-yum clean all
-rm -rf /var/cache/yum
+apt -y update && apt install --no-install-recommends -y wget gpg ca-certificates
+wget -O - https://apt.corretto.aws/corretto.key | gpg --dearmor -o /usr/share/keyrings/corretto-keyring.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/corretto-keyring.gpg] https://apt.corretto.aws stable main" | tee /etc/apt/sources.list.d/corretto.list
+apt -y update && apt install --no-install-recommends -y \
+ java-11-amazon-corretto-jdk \
+ xmlstarlet \
+ jq \
+ gnupg \
+ python3 \
+ python3-pip \
+ git \
+ zip \
+ curl \
+ wget \
+ awscli \
+ maven && rm -rf /var/lib/apt/lists/*
 
-pip3 install --upgrade pip
-# The upgrade will remove the pip3 binary and replace it with pip
-pip install awscli
+apt clean
+rm -rf /usr/lib/jvm/java-11-amazon-corretto/lib/src.zip 
 
 mkdir /maven


### PR DESCRIPTION
# Description

We have experienced a number of issues with the base container (AL2 and then AL2023) we were using before. This change replaces the base container with a bit easier to work with `debian:bookworm-20240701-slim` and recreates our infra (amazon-corretto-11, maven 3.8, etc) on this new base. 

As part of this, we've updated packer to 1.11, moved the configuration file to Packer HCL and added an option to abort (fail) the build if there are errorsduring the image creation (for future visibility of errors).

This was tested by creating a new container image (`pipeline-java:4.5.0`), bumping a version in the maven pipeline (https://github.com/zepben/.github/pull/42) and running the build using that pipeline (https://github.com/zepben/mvn-app-ci-test/actions/runs/9959123594/job/27515190615).

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~