### PR TITLE
OPS-223: Remove google mirror for maven central

### DIFF
--- a/pipelines/Java/amazoncorretto-config.pkr.hcl
+++ b/pipelines/Java/amazoncorretto-config.pkr.hcl
@@ -58,7 +58,7 @@ build {
     post-processor "docker-tag" {
       name       = "docker.tag"
       repository = "zepben/pipeline-java"
-      tags       = ["4.5.1"]
+      tags       = ["4.5.2"]
     }
     post-processor "docker-push" {
       name           = "docker.push"

--- a/pipelines/Java/maven-settings.xml
+++ b/pipelines/Java/maven-settings.xml
@@ -3,14 +3,6 @@
 xmlns="http://maven.apache.org/SETTINGS/1.1.0"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <localRepository>/maven</localRepository>
-    <mirrors>
-        <mirror>
-            <id>google-maven-central</id>
-            <name>GCS Maven Central mirror</name>
-            <url>https://maven-central.storage-download.googleapis.com/maven2/</url>
-            <mirrorOf>central</mirrorOf>
-        </mirror>
-    </mirrors>
     <servers>
         <server>
             <username>${server.username}</username>


### PR DESCRIPTION
# Description

The Google mirror for maven central was causing issues due to missing artifacts (see https://github.com/zepben/evolve-app-server/actions/runs/9968894644/job/27723892807). For this reason, we are removing that mirror.

# Associated tasks

Tasks blocking this one:
- None

Tasks this is blocking:
- https://app.clickup.com/t/6929263/OPS-224
- https://github.com/zepben/evolve-app-server/pull/93

# Test Steps

May be tested manually by using the `maven-settings.xml` file locally and ensuring that dependencies are downloaded from the official maven-central (https://repo1.maven.org/maven2/) instead of the google one (https://maven-central.storage-download.googleapis.com).

# Checklist

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~ (No unit tests needed for `maven-settings.xml` change)
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

No breaking changes.
