### PR TITLE
[OPS-239] Overwrite the  $new_version to propagate properly

### DIFF
--- a/pipelines/CSharp/scripts/cs-common.sh
+++ b/pipelines/CSharp/scripts/cs-common.sh
@@ -57,23 +57,23 @@ deploy_lib(){
 }
 
 write_new_version(){
-    old_ver=${1:? 'Old version is required.'}
-    new_ver=${2:? 'New version is required.'}
+    old_version=${1:? 'Old version is required.'}
+    new_version=${2:? 'New version is required.'}
 
-    if [[ $old_ver != $new_ver ]]; then
-        info "Writing new version $new_ver..."
+    if [[ $old_version != $new_version ]]; then
+        info "Writing new version $new_version..."
         if [[ $file == *".csproj" ]]; then
-            run xmlstarlet ed -P -L -u "/Project/PropertyGroup/Version" -v $new_ver $file
-            pre=${new_ver#*"-pre"}
-            sem_version=${new_ver%-pre*}
-            if [[ $new_ver == *"-pre"* ]]; then
+            run xmlstarlet ed -P -L -u "/Project/PropertyGroup/Version" -v $new_version $file
+            pre=${new_version#*"-pre"}
+            sem_version=${new_version%-pre*}
+            if [[ $new_version == *"-pre"* ]]; then
                 run xmlstarlet ed -P -L -u "/Project/PropertyGroup/AssemblyVersion" -v "${sem_version}.${pre}" $file
                 run xmlstarlet ed -P -L -u "/Project/PropertyGroup/FileVersion" -v "${sem_version}.${pre}" $file
             fi
         elif [[ $file == *".nuspec" ]]; then
-            run xmlstarlet ed -P -L -u "/package/metadata/version" -v $new_ver $file
+            run xmlstarlet ed -P -L -u "/package/metadata/version" -v $new_version $file
         else
-            sed -i "s/$old_ver/$new_ver/g" $file
+            sed -i "s/$old_version/$new_version/g" $file
         fi
     fi
 }

--- a/pipelines/Java/scripts/java-common.sh
+++ b/pipelines/Java/scripts/java-common.sh
@@ -50,12 +50,12 @@ package(){
 }
 
 write_new_version(){
-    old_ver=${1:? 'Old version is required.'}
-    new_ver=${2:? 'New version is required.'}
+    old_version=${1:? 'Old version is required.'}
+    new_version=${2:? 'New version is required.'}
 
-    if [[ $old_ver != $new_ver ]]; then
-        info "Writing new version $new_ver..."
-        java_write_new_version "$old_ver" "$new_ver"
+    if [[ $old_version != $new_version ]]; then
+        info "Writing new version $new_version..."
+        java_write_new_version "$old_version" "$new_version"
     fi
 }
 

--- a/pipelines/JavaScript/scripts/js-common.sh
+++ b/pipelines/JavaScript/scripts/js-common.sh
@@ -42,12 +42,12 @@ package(){
 }
 
 write_new_version(){
-    old_ver=${1:? 'Old version is required.'}
-    new_ver=${2:? 'New version is required.'}
+    old_version=${1:? 'Old version is required.'}
+    new_version=${2:? 'New version is required.'}
 
     if [[ $old_ver != $new_ver ]]; then
-        info "Writing new version $new_ver..."
-        run jq --arg VERSION $new_ver '.version = $VERSION' $file
+        info "Writing new version $new_version..."
+        run jq --arg VERSION $new_verion '.version = $VERSION' $file
         run cp -f $output_file $file
     fi
 }

--- a/pipelines/JavaScript/scripts/js-common.sh
+++ b/pipelines/JavaScript/scripts/js-common.sh
@@ -47,7 +47,7 @@ write_new_version(){
 
     if [[ $old_ver != $new_ver ]]; then
         info "Writing new version $new_version..."
-        run jq --arg VERSION $new_verion '.version = $VERSION' $file
+        run jq --arg VERSION $new_version '.version = $VERSION' $file
         run cp -f $output_file $file
     fi
 }

--- a/pipelines/Python/scripts/py-common.sh
+++ b/pipelines/Python/scripts/py-common.sh
@@ -33,12 +33,12 @@ deploy_lib(){
 }
 
 write_new_version(){
-    old_ver=${1:? 'Old version is required.'}
-    new_ver=${2:? 'New version is required.'}
+    old_version=${1:? 'Old version is required.'}
+    new_version=${2:? 'New version is required.'}
 
-    if [[ $old_ver != $new_ver ]]; then
-        info "Writing new version $new_ver..."
-        run sed -i "/version[[:space:]]*=[[:space:]]*/s/$old_ver/$new_ver/" $file
+    if [[ $old_version != $new_version ]]; then
+        info "Writing new version $new_version..."
+        run sed -i "/version[[:space:]]*=[[:space:]]*/s/$old_version/$new_version/" $file
     fi
 }
 


### PR DESCRIPTION
# Description

The non-mvn flows do not update `$new_version` paramer leading to incorrect commit messages for all non-mvn repos. 

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).