### PR TITLE
Fix variable typo, x_ver should be x_version

### DIFF
--- a/pipelines/JavaScript/scripts/js-common.sh
+++ b/pipelines/JavaScript/scripts/js-common.sh
@@ -45,7 +45,7 @@ write_new_version(){
     old_version=${1:? 'Old version is required.'}
     new_version=${2:? 'New version is required.'}
 
-    if [[ $old_ver != $new_ver ]]; then
+    if [[ $old_version != $new_version ]]; then
         info "Writing new version $new_version..."
         run jq --arg VERSION $new_version '.version = $VERSION' $file
         run cp -f $output_file $file


### PR DESCRIPTION
# Description

In https://github.com/zepben/ci-utils/pull/15 we updated the variable names, but missed one. This caused a build error like this: https://github.com/zepben/network-map/actions/runs/11157413186/job/31058232462#step:5:161, where we then failed to update the package version, and the snapshot release workflow failed.

This PR fixes the variable names.

# Associated tasks

None.

# Test Steps

None.

# Checklist

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [ ] ~I have commented my code in any hard-to-understand or hacky areas.~
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [ ] ~I have updated the changelog.~
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [ ] ~I have considered if this is a breaking change and will communicate it with other team members if so.~