### PR TITLE
[OPS 258] Remove release branch

### DIFF
--- a/.github/workflows/build-pipelines.yml
+++ b/.github/workflows/build-pipelines.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Create release branch
         run: |
           git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-          git fetch -v
+          git fetch -v origin
           # If the `release` branch already exists, remove it
           run git push origin -d release
           git checkout -b release

--- a/.github/workflows/build-pipelines.yml
+++ b/.github/workflows/build-pipelines.yml
@@ -22,7 +22,12 @@ jobs:
       - name: Create release branch
         run: |
           git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-          git fetch --all
+          git fetch -v
+          git branch | grep release
+          if [ $? -eq 0 ]; then 
+            # Release branch already exists, remove it
+            git push origin -d release
+          fi
           git checkout -b release
         shell: bash
 

--- a/.github/workflows/build-pipelines.yml
+++ b/.github/workflows/build-pipelines.yml
@@ -23,11 +23,8 @@ jobs:
         run: |
           git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
           git fetch -v
-          git branch | grep release
-          if [ $? -eq 0 ]; then 
-            # Release branch already exists, remove it
-            git push origin -d release
-          fi
+          # If the `release` branch already exists, remove it
+          run git push origin -d release
           git checkout -b release
         shell: bash
 

--- a/.github/workflows/build-pipelines.yml
+++ b/.github/workflows/build-pipelines.yml
@@ -147,6 +147,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ env.GITHUB_TOKEN }}
+
       - name: Work around git permission issue
         run: |
           dname=$(echo ${{github.repository}} | cut -d'/' -f2)

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,13 @@
 # CI-Utils
 ## [6.1.0] - UNRELEASED
 ### Breaking Changes
-* Rebuild the way containers are created - all containers are latest + tag; only tag if in testing.
+* None
 
 ### New Features
 * None.
 
 ### Enhancements
-* None.
+* Clear the release branch if it exists during release checks.
 
 ### Fixes
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,21 @@
 # CI-Utils
-## [6.0.0] - UNRELEASED
+## [6.1.0] - UNRELEASED
+### Breaking Changes
+* Rebuild the way containers are created - all containers are latest + tag; only tag if in testing.
+
+### New Features
+* None.
+
+### Enhancements
+* None.
+
+### Fixes
+* None.
+
+### Notes
+* None.
+
+## [6.0.0] - October 24, 2024
 ### Breaking Changes
 * Rebuild the way containers are created - all containers are latest + tag; only tag if in testing.
 

--- a/pipelines/basic/scripts/release-checks.sh
+++ b/pipelines/basic/scripts/release-checks.sh
@@ -40,6 +40,14 @@ do
     fi
 done
 
+info "Clearing the 'release' branch if it exists"
+git branch | grep release
+if [ $? == 0 ]; then
+    # Found release branch, let's drop it
+    info "Found 'release' branch, removing it"
+    run git push origin -d release
+fi
+
 # Get user name
 if [[ -z "$BITBUCKET_STEP_TRIGGERER_UUID" ]]; then
   USERNAME=$(curl -s -X GET -g "https://api.bitbucket.org/2.0/users/${BITBUCKET_STEP_TRIGGERER_UUID}" | jq --raw-output '.display_name')

--- a/pipelines/basic/scripts/release-checks.sh
+++ b/pipelines/basic/scripts/release-checks.sh
@@ -40,12 +40,15 @@ do
     fi
 done
 
-info "Clearing the 'release' branch if it exists"
-git branch | grep release
-if [ $? == 0 ]; then
-    # Found release branch, let's drop it
-    info "Found 'release' branch, removing it"
-    run git push origin -d release
+# In most cases the error here means that the "release" branch doesn't exist.
+# If that's not the case, one the following steps will fail, and will be handled
+# manually
+info "Clearing the 'release' branch if it exists, ignore errors"
+run git push origin -d release
+if [ $status -ne 0 ]; then
+    # Show the error and continue 
+    echo "Warning: There was an error deleting a release branch: "
+    cat "${output_file}"
 fi
 
 # Get user name

--- a/pipelines/basic/scripts/release-checks.sh
+++ b/pipelines/basic/scripts/release-checks.sh
@@ -40,11 +40,11 @@ do
     fi
 done
 
-# In most cases the error here means that the "release" branch doesn't exist.
-# If that's not the case, one the following steps will fail, and will be handled
-# manually
 info "Clearing the 'release' branch if it exists, ignore errors"
 run git push origin -d release
+# In most cases the error here means that the "release" branch doesn't exist.
+# If that's not the case, one the following steps will fail, and will be handled
+# manually, so we ignore the error here and only showing it.
 if [ $status -ne 0 ]; then
     # Show the error and continue 
     echo "Warning: There was an error deleting a release branch: "


### PR DESCRIPTION
Always remove the release branch during release checks.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~