### PR TITLE
[OPS-302] Allow run() call to proceed on error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 * None.
 
 ### Enhancements
-* None.
+* run() command (from `common.sh`) disables `set -e` temporarily for its run; it's needed so that it can proceed on errors.
 
 ### Fixes
 * None.

--- a/pipelines/scripts/common.sh
+++ b/pipelines/scripts/common.sh
@@ -99,6 +99,8 @@ enable_debug() {
 #   None
 #######################################
 run() {
+  # temporary allow continue on errors
+  set +e
   echo "$@"
   if [[ "$@" = "cd "* ]]; then
     "$@"
@@ -107,6 +109,8 @@ run() {
     "$@" | tee "$output_file"
   fi
   status=$?
+  # restore fail on errors
+  set -e
 }
 
 #######################################


### PR DESCRIPTION
# Description

`run()` function allows us to wrap shell execution in CI and handle outputs in case of an error. This change allows it to continue execution and not fail immediately. 

# Test Steps
Release container and test if release-checks step is working.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~
- [x] I have commented my code in any hard-to-understand or hacky areas.
~- [ ] I have handled all new warnings generated by the compiler or IDE.~
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

This change is not breaking by itself, but may have unforeseen consequences where we rely on things failing and not handling that properly.  However, this is the expected behaviour, because the function returns `status`, which would make no sense if the function failed before hand and stopped execution.