### PR TITLE
[OPS-366] Rename ossrh to maven-central for posterity

### DIFF
--- a/pipelines/Java/maven-settings.xml
+++ b/pipelines/Java/maven-settings.xml
@@ -10,9 +10,9 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <id>zepben-maven</id>
         </server>
         <server>
-            <id>ossrh</id>
-            <username>${ossrh.server.username}</username>
-            <password>${ossrh.server.password}</password>
+            <id>maven-central</id>
+            <username>${maven-central.server.username}</username>
+            <password>${maven-central.server.password}</password>
         </server>
         <server>
             <id>${gpg.key}</id>
@@ -21,7 +21,7 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     </servers>
     <profiles>
         <profile>
-            <id>ossrh</id>
+            <id>maven-central</id>
             <properties>
                 <gpg.keyname>${gpg.key}</gpg.keyname>
                 <gpg.executable>gpg</gpg.executable>
@@ -64,6 +64,6 @@ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     </profiles>
     <activeProfiles>
         <activeProfile>zepben-maven</activeProfile>
-        <activeProfile>ossrh</activeProfile>
+        <activeProfile>maven-central</activeProfile>
     </activeProfiles>
 </settings>


### PR DESCRIPTION
Rename `ossrh` profile to `maven-central` so that we do not confuse them in the future.
This change is not technically required, but as `ossrh` is being sunset, if we keep the name it will confuse our team in the future if kept.

Related PRs:

- https://github.com/zepben/maven-deploy-central-action/pull/6
- https://github.com/zepben/.github/pull/73
- https://github.com/zepben/ewb-super-pom/pull/58

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

This change is breaking and has to be merged as a concerned effort together will other tasks in the related list; otherwise some parts of the flow will not function properly.