### PR TITLE
Fix the sed pattern to properly remove 'b' from snapshots

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 * None.
 
 ### Fixes
-* None.
+* Fix sed pattern for removing 'b' from snapshots in maven builds.
 
 ### Notes
 * None.

--- a/pipelines/Java/scripts/java-common.sh
+++ b/pipelines/Java/scripts/java-common.sh
@@ -77,7 +77,8 @@ find_unreleased_version() {
 
 finalize_version(){
     new_version=${version/b*/}
-    sed -i "s/b[0-9]*//g; s/-SNAPSHOT[0-9]*//g" $file
+    sed -i "s/\(<version>.*\)b.*\(<\/version>\)/\1\2/g; s/-SNAPSHOT[0-9]*//g" $file
+
 }
 
 check_release_version(){


### PR DESCRIPTION
# Description

Fix the sed pattern to properly remove 'b' from snapshots.