### PR TITLE
Gitleaks: bump entropy to 4.0

### DIFF
--- a/pipelines/basic/gitleaks.toml
+++ b/pipelines/basic/gitleaks.toml
@@ -7,7 +7,7 @@ useDefault = true
 id = "low-entropy-api-key"
 description = "Detected a Generic API Key, potentially exposing access to various services and sensitive operations."
 regex = '''(?i)[\w.-]{0,50}?(?:access|auth|(?-i:[Aa]pi|API)|credential|creds|key|passwd|password|secret|token)(?:[ \t\w.-]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([\w.=-]{5,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
-entropy = 2.9
+entropy = 4.0
 keywords = [
     "access",
     "api",


### PR DESCRIPTION
# Description

Need to bump entropy again as `gitleaks` picks up too much noise.