### PR TITLE
[Docusaurus Pipeline] Fix the release notes link to be relative

### DIFF
--- a/pipelines/Docusaurus/templates/build.sh
+++ b/pipelines/Docusaurus/templates/build.sh
@@ -83,8 +83,10 @@ function configure_site() {
     # link the current docs, it works fine
     ln -s ../docs .
 
-    # link the release-notes, same
-    ln -s ${release_notes} src/pages/release-notes.md
+    # link the release-notes
+    pushd src/pages
+    ln -s ../../release-notes.md .
+    popd
 
     # cleanup
     rm -rf *template*


### PR DESCRIPTION
# Description

[Docusaurus Pipeline] Fix the release notes link to be relative, not absolute.