### PR TITLE
Fixed errors in copying `next` spec files when they exist

### DIFF
--- a/pipelines/Docusaurus/templates/build.sh
+++ b/pipelines/Docusaurus/templates/build.sh
@@ -109,7 +109,7 @@ function configure_site() {
         fi
 
         echo "copying next spec..."
-        cp -r "${docs}/docs/spec/" static/spec/next
+        cp -r "${docs}/docs/spec/." static/spec/next
         echo "copying archive specs..."
         cp -r "${archive}/versioned_spec/." static/spec/
     fi


### PR DESCRIPTION
# Description

Simple fix that isn't an issue in CI, as it has a fresh file system each run. When running locally, this prevents creating a nested `spec` folder under `next` instead of copying the contents.