### PR TITLE
Support ct.yaml contains required deps

### DIFF
--- a/local-k8s/src/local_k8s/commands/chart/lint.py
+++ b/local-k8s/src/local_k8s/commands/chart/lint.py
@@ -5,6 +5,7 @@ from subprocess import CalledProcessError
 import click
 from click import ClickException
 
+from local_k8s.models import ChartMetadata, ChartTestingConfig
 from local_k8s.shared import execute, resolve_chart
 from local_k8s.static import CT_YAML
 
@@ -32,11 +33,16 @@ from local_k8s.static import CT_YAML
 )
 def lint(helm_dir: Path, chart: Path) -> None:
     helm_dir = helm_dir.resolve()
-    if not (helm_dir / CT_YAML).is_file():
+    ct_path = helm_dir / CT_YAML
+    if not ct_path.is_file():
         raise ClickException(f"{CT_YAML} is required in the root of --helm-dir")
 
     resolved_chart = resolve_chart(helm_dir, chart)
-
+    ct_config = ChartTestingConfig.from_chart_dir(helm_dir)
+    chart_metadata = ChartMetadata.from_chart_dir(
+        resolved_chart.path_relative_to_helm_dir
+    )
+    validate_dependencies_present(chart_metadata, ct_config, ct_path)
     with chdir(helm_dir):
         try:
             execute(
@@ -50,3 +56,15 @@ def lint(helm_dir: Path, chart: Path) -> None:
             )
         except CalledProcessError as e:
             raise ClickException(f"lint failed with rc={e.returncode}") from e
+
+
+def validate_dependencies_present(
+    chart_metadata: ChartMetadata, ct_config: ChartTestingConfig, ct_path: Path
+) -> None:
+    # Syntax is <name>=<url>
+    chart_repos = [repo.split("=")[-1] for repo in ct_config.chart_repos]
+    for dependency in chart_metadata.dependencies:
+        if dependency.repository not in chart_repos:
+            raise ClickException(
+                f"{dependency.repository} not found in {ct_path}. It needs to be added under the chart_repos list, in the format <name>=<url>"
+            )

--- a/local-k8s/src/local_k8s/models.py
+++ b/local-k8s/src/local_k8s/models.py
@@ -46,6 +46,29 @@ class ClusterComponents(BaseModel):
         return cls.model_validate(data)
 
 
+class ChartTestingConfig(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    remote: str
+    target_branch: str = Field(alias="target-branch")
+    chart_dirs: list[Path] = Field(alias="chart-dirs")
+    chart_repos: list[str] = Field(default_factory=list, alias="chart-repos")
+    validate_maintainers: bool = Field(alias="validate-maintainers")
+    check_version_increment: bool = Field(alias="check-version-increment")
+    namespace: str
+    release_label: str = Field(alias="release-label")
+    additional_commands: list[str] = Field(
+        default_factory=list, alias="additional-commands"
+    )
+
+    @classmethod
+    def from_chart_dir(cls, chart_dir: Path) -> Self:
+        chart_yaml = chart_dir / "ct.yaml"
+        if not chart_yaml.is_file():
+            raise ValueError(f"ct.yaml not found at {chart_yaml}")
+        return cls.model_validate(yaml.safe_load(chart_yaml.read_text()))
+
+
 class CiSecret(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -65,6 +88,14 @@ class CiSecrets(BaseModel):
     secrets: list[CiSecret]
 
 
+class ChartDependency(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    name: str = Field(min_length=1)
+    version: str = Field(min_length=1)
+    repository: str = Field(min_length=1)
+
+
 class ChartMetadata(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
@@ -72,6 +103,7 @@ class ChartMetadata(BaseModel):
     version: str = Field(min_length=1)
     type: str = "application"
     appVersion: str | None = None
+    dependencies: list[ChartDependency] = Field(default_factory=list)
 
     @classmethod
     def from_chart_dir(cls, chart_dir: Path) -> Self:

--- a/local-k8s/tests/test_chart_lint.py
+++ b/local-k8s/tests/test_chart_lint.py
@@ -1,0 +1,119 @@
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import call
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from _charts import write_chart
+from _fake_execute import FakeExecute
+from local_k8s.cli import cli
+from local_k8s.commands.chart import lint as lint_module
+from local_k8s.models import ChartTestingConfig
+
+
+@pytest.fixture
+def chart_testing_config() -> ChartTestingConfig:
+    return ChartTestingConfig.model_validate(
+        {
+            "remote": "origin",
+            "target-branch": "main",
+            "chart-dirs": ["charts"],
+            "chart-repos": ["example-repo=https://example.com/helm-charts"],
+            "validate-maintainers": False,
+            "check-version-increment": False,
+            "namespace": "chart-testing",
+            "release-label": "app.kubernetes.io/instance",
+            "additional-commands": [],
+        }
+    )
+
+
+@pytest.fixture
+def write_chart_testing_config(
+    helm_dir: Path,
+) -> Callable[[ChartTestingConfig], None]:
+    def write(config: ChartTestingConfig) -> None:
+        (helm_dir / "ct.yaml").write_text(
+            yaml.safe_dump(
+                config.model_dump(by_alias=True, mode="json"), sort_keys=False
+            )
+        )
+
+    return write
+
+
+@pytest.fixture
+def dependent_chart(helm_dir: Path) -> Path:
+    return write_chart(
+        helm_dir / "charts" / "example-chart",
+        {
+            "apiVersion": "v2",
+            "name": "example-chart",
+            "version": "0.2.0",
+            "dependencies": [
+                {
+                    "name": "example-dependency",
+                    "version": "1.10.0",
+                    "repository": "https://example.com/helm-charts",
+                }
+            ],
+        },
+    )
+
+
+def test_lint_dependency_repository_present_runs_ct(
+    helm_dir: Path,
+    chart_testing_config: ChartTestingConfig,
+    dependent_chart: Path,
+    write_chart_testing_config: Callable[[ChartTestingConfig], None],
+    fake_execute: Callable[[ModuleType], FakeExecute],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_chart_testing_config(chart_testing_config)
+    fake = fake_execute(lint_module).on("ct", "lint")
+
+    monkeypatch.chdir(helm_dir)
+    result = CliRunner().invoke(
+        cli,
+        ["chart", "lint", "--helm-dir", ".", "--chart", "charts/example-chart"],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls_for("ct") == [
+        call(
+            "ct",
+            "lint",
+            "--config",
+            "ct.yaml",
+            "--charts",
+            "charts/example-chart",
+            "--check-version-increment=true",
+        )
+    ]
+
+
+def test_lint_dependency_repository_missing_from_ct_config_fails(
+    helm_dir: Path,
+    chart_testing_config: ChartTestingConfig,
+    dependent_chart: Path,
+    write_chart_testing_config: Callable[[ChartTestingConfig], None],
+    fake_execute: Callable[[ModuleType], FakeExecute],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chart_testing_config.chart_repos = ["other-repo=https://other.example.com/charts"]
+    write_chart_testing_config(chart_testing_config)
+    fake = fake_execute(lint_module).on("ct", "lint")
+
+    monkeypatch.chdir(helm_dir)
+    result = CliRunner().invoke(
+        cli,
+        ["chart", "lint", "--helm-dir", ".", "--chart", "charts/example-chart"],
+    )
+
+    assert result.exit_code != 0
+    assert "https://example.com/helm-charts not found" in result.output
+    assert "ct.yaml" in result.output
+    assert fake.calls_for("ct") == []

--- a/local-k8s/tests/test_chart_metadata.py
+++ b/local-k8s/tests/test_chart_metadata.py
@@ -13,6 +13,7 @@ def test_metadata_full_fields(tmp_path: Path) -> None:
         "version": "1.2.3",
         "type": "library",
         "appVersion": "9.0",
+        "dependencies": [],
     }
     chart_dir = write_chart(tmp_path / "mychart", chart_yaml)
 


### PR DESCRIPTION
When we add dependencies in Chart.yaml, the ct lint command requires they be installed or it fails with an obscure error. To make it a bit clearer what happened and what people should do about it, add some validation to the lint command that ct.yaml contains the required repositories and raise a useful error if not.