### PR TITLE
Support bind mounting local git repos and wiring up Argo to use them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ format-zep-dev: $(VENV)
 check-zep-dev: $(VENV)
 	$(BIN)/ruff format --check $(ZEP_DEV)
 	$(BIN)/ruff check $(ZEP_DEV)
-	cd $(ZEP_DEV) && ../$(BIN)/mypy -p zep_dev
+	$(BIN)/mypy .
 
 test-zep-dev: $(VENV)
 	cd $(ZEP_DEV) && ../$(BIN)/pytest

--- a/zep-dev/examples/components.yaml
+++ b/zep-dev/examples/components.yaml
@@ -5,6 +5,11 @@ cluster_components:
     chart: argo/argo-cd
     version: "9.5.0"
     namespace: argo-cd
+    # Signals to zep-dev to apply the extra ArgoCD values overlay
+    # that ensures we always schedule on a worker with the correct
+    # mounts, and that the expected env variables exist, etc.
+    local_repo_integration: argo-cd
+    # Complete values to be passed to helm.
     values:
       applicationSet:
         replicas: 1

--- a/zep-dev/examples/components.yaml
+++ b/zep-dev/examples/components.yaml
@@ -1,26 +1,44 @@
 helm_repos:
-  argocd: "https://argoproj.github.io/argo-helm"
+  argo: "https://argoproj.github.io/argo-helm"
 cluster_components:
-  - name: argocd
-    chart: argocd/argo-cd
-    version: "10.0.1"
-    namespace: argocd
-    set:
-      applicationSet.replicas: "1"
-      configs.cm.admin.enabled: "true"
-      configs.params.server.insecure: "true"
-      controller.replicas: "1"
-      dex.enabled: "false"
-      global.affinity.nodeAffinity.type: "none"
-      global.affinity.podAntiAffinity: "none"
-      global.networkPolicy.create: "false"
-      notifications.enabled: "false"
-      redis-ha.enabled: "false"
-      repoServer.autoscaling.enabled: "false"
-      repoServer.replicas: "1"
-      server.autoscaling.enabled: "false"
-      server.ingress.enabled: "false"
-      server.replicas: "1"
-      # Expose to the host so we can browse without port-forwarding, see kind-cluster.yaml
-      server.service.nodePortHttp: "30080"
-      server.service.type: "NodePort"
+  - name: argo-cd
+    chart: argo/argo-cd
+    version: "9.5.0"
+    namespace: argo-cd
+    values:
+      applicationSet:
+        replicas: 1
+      configs:
+        cm:
+          admin.enabled: true
+        params:
+          server.insecure: true
+      controller:
+        replicas: 1
+      dex:
+        enabled: false
+      global:
+        affinity:
+          nodeAffinity:
+            type: none
+          podAntiAffinity: none
+        networkPolicy:
+          create: false
+      notifications:
+        enabled: false
+      redis-ha:
+        enabled: false
+      repoServer:
+        autoscaling:
+          enabled: false
+        replicas: 1
+      server:
+        autoscaling:
+          enabled: false
+        ingress:
+          enabled: false
+        replicas: 1
+        # Expose to the host so we can browse without port-forwarding, see kind-cluster.yaml
+        service:
+          nodePortHttp: 30080
+          type: NodePort

--- a/zep-dev/pyproject.toml
+++ b/zep-dev/pyproject.toml
@@ -52,6 +52,5 @@ testpaths = ["tests"]
 python_version = "3.14"
 strict = true
 warn_unused_configs = true
-files = ["src/zep_dev"]
 mypy_path = "src"
 explicit_package_bases = true

--- a/zep-dev/pyproject.toml
+++ b/zep-dev/pyproject.toml
@@ -51,5 +51,7 @@ testpaths = ["tests"]
 [tool.mypy]
 python_version = "3.14"
 strict = true
+warn_unused_configs = true
+files = ["src/zep_dev"]
 mypy_path = "src"
 explicit_package_bases = true

--- a/zep-dev/src/zep_dev/cluster.py
+++ b/zep-dev/src/zep_dev/cluster.py
@@ -1,13 +1,21 @@
+import json
 import logging
 import os
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager, nullcontext
 from pathlib import Path
+from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
+from typing import Any
 
 import yaml
+from click import ClickException
 
-from zep_dev.models import ClusterComponents
+from zep_dev.models import (
+    LOCAL_REPO_MOUNT_ROOT,
+    ClusterComponents,
+    LocalRepo,
+)
 from zep_dev.shared import CommandResult, execute
 
 CLUSTER_NAME = "test-cluster"
@@ -34,29 +42,77 @@ def kube_guard() -> Generator[None]:
         os.environ.pop("KUBECONFIG", None)
 
 
-def create_cluster(kind_config: Path, components: ClusterComponents) -> None:
-    _create_kind_cluster(kind_config)
+def create_cluster(
+    kind_config: Path,
+    components: ClusterComponents,
+    local_repos: Sequence[Path] = (),
+) -> None:
+    repos = _load_local_repos(local_repos)
+    _create_kind_cluster(kind_config, repos)
     _add_helm_repos(components)
     _install_helm_components(components)
 
 
-def _create_kind_cluster(kind_config: Path) -> None:
-    LOG.info("Creating kind cluster")
-    for line in kind(
-        "get", "clusters", "--quiet", capture_stdout=True
-    ).stdout.splitlines():
-        if line == CLUSTER_NAME:
-            LOG.info("Reusing existing cluster: %s", CLUSTER_NAME)
-            break
-    else:
-        kind(
-            "create",
-            "cluster",
-            "--name",
-            CLUSTER_NAME,
-            "--config",
-            str(kind_config),
+def _load_local_repos(paths: Sequence[Path]) -> tuple[LocalRepo, ...]:
+    repos = tuple(LocalRepo(path=path.resolve()) for path in paths)
+    seen: set[str] = set()
+    for repo in repos:
+        if repo.basename in seen:
+            raise ClickException(f"duplicate --local-repo basename: {repo.basename}")
+        seen.add(repo.basename)
+        _validate_repo(repo)
+    return repos
+
+
+def _validate_repo(repo: LocalRepo) -> None:
+    try:
+        toplevel = Path(
+            execute(
+                "git",
+                "-C",
+                str(repo.path),
+                "rev-parse",
+                "--show-toplevel",
+                skip_resolve=True,
+                capture_stdout=True,
+            ).stdout.strip()
+        ).resolve()
+    except CalledProcessError as e:
+        raise ClickException(f"--local-repo is not a Git work tree: {repo.path}") from e
+    if repo.path != toplevel:
+        raise ClickException(
+            f"--local-repo must be a Git repository toplevel: {repo.path} "
+            f"(toplevel is {toplevel})"
         )
+
+
+def _create_kind_cluster(kind_config: Path, local_repos: Sequence[LocalRepo]) -> None:
+    LOG.info("Creating kind cluster")
+    existing = kind(
+        "get", "clusters", "--quiet", capture_stdout=True
+    ).stdout.splitlines()
+    if CLUSTER_NAME in existing:
+        if local_repos:
+            # Ensure that if we have a running cluster, the mounts are the same
+            # as passed on the command line. Otherwise we would have a silent
+            # and confusing failure mode.
+            _validate_existing_worker_mounts(local_repos)
+        LOG.info("Reusing existing cluster: %s", CLUSTER_NAME)
+        return
+
+    rendered_config = _inject_repo_mounts(kind_config, local_repos)
+
+    config_path = Path("/tmp/kind-config.yaml")
+    config_path.write_text(rendered_config, encoding="utf-8")
+
+    kind(
+        "create",
+        "cluster",
+        "--name",
+        CLUSTER_NAME,
+        "--config",
+        str(config_path),
+    )
     kind(
         "export",
         "kubeconfig",
@@ -65,6 +121,86 @@ def _create_kind_cluster(kind_config: Path) -> None:
         "--kubeconfig",
         str(KUBECONF_PATH),
     )
+
+
+def _validate_existing_worker_mounts(local_repos: Sequence[LocalRepo]) -> None:
+    """
+    Call podman and extract the mounts our running kind cluster has configured.
+    If they are not the exact same set as we have passed on the command line --local-repos,
+    fail.
+    """
+    out = kind("get", "nodes", "--name", CLUSTER_NAME, capture_stdout=True)
+    workers = tuple(
+        name for name in out.stdout.splitlines() if not name.endswith("-control-plane")
+    )
+    if not workers:
+        raise ClickException("--local-repo requires at least one worker node.")
+
+    expected_mounts = {(str(repo.path), repo.container_path) for repo in local_repos}
+    for worker in workers:
+        existing_mounts = _inspect_live_mounts(worker)
+        if existing_mounts != expected_mounts:
+            raise ClickException(
+                "Existing cluster local-repo mounts do not match --local-repo. "
+                "Run: zep-dev cluster teardown"
+            )
+
+
+def _inspect_live_mounts(worker: str) -> set[tuple[str, str]]:
+    raw_mounts = podman(
+        "inspect",
+        worker,
+        "--format",
+        "{{json .Mounts}}",
+        capture_stdout=True,
+    ).stdout
+    mounts: Any = json.loads(raw_mounts)
+    if not isinstance(mounts, list):
+        raise ClickException(f"podman inspect returned invalid mounts for {worker}")
+
+    local_mounts = set()
+    for mount in mounts:
+        if not isinstance(mount, dict):
+            continue
+        if mount.get("Type") != "bind":
+            continue
+        source = mount.get("Source")
+        destination = mount.get("Destination")
+        if not isinstance(source, str) or not isinstance(destination, str):
+            continue
+        if not destination.startswith(f"{LOCAL_REPO_MOUNT_ROOT}/"):
+            continue
+        local_mounts.add((str(Path(source).resolve()), destination))
+
+    return local_mounts
+
+
+def _inject_repo_mounts(kind_config: Path, repos: Sequence[LocalRepo]) -> str:
+    config: Any = yaml.safe_load(kind_config.read_text(encoding="utf-8"))
+    if not isinstance(config, dict):
+        raise ClickException(f"kind config must be a mapping: {kind_config}")
+
+    nodes = config.get("nodes", [])
+    workers = [node for node in nodes if node.get("role") == "worker"]
+    if not workers:
+        raise ClickException(
+            "--local-repo requires at least one worker node in the kind config"
+        )
+
+    # Workers only: control-plane gets no extraMounts. The Argo overlay prevents
+    # Argo pods being scheduled on the control-plane nodes.
+    for worker in workers:
+        mounts = worker.setdefault("extraMounts", [])
+        mounts.extend(
+            {
+                "hostPath": str(repo.path),
+                "containerPath": repo.container_path,
+                "readOnly": True,
+            }
+            for repo in repos
+        )
+
+    return yaml.safe_dump(config, default_flow_style=False)
 
 
 def _add_helm_repos(components: ClusterComponents) -> None:
@@ -152,6 +288,15 @@ def dump_to_stdout(filter_namespaces: list[str], out_dir: Path) -> None:
 
 def kind(*args: str, capture_stdout: bool = False) -> CommandResult:
     return execute("kind", *args, capture_stdout=capture_stdout)
+
+
+def podman(*args: str, capture_stdout: bool = False) -> CommandResult:
+    return execute(
+        "podman",
+        *args,
+        capture_stdout=capture_stdout,
+        skip_resolve=True,
+    )
 
 
 def helm(*args: str, capture_stdout: bool = False) -> CommandResult:

--- a/zep-dev/src/zep_dev/cluster.py
+++ b/zep-dev/src/zep_dev/cluster.py
@@ -50,7 +50,7 @@ def create_cluster(
     repos = _load_local_repos(local_repos)
     _create_kind_cluster(kind_config, repos)
     _add_helm_repos(components)
-    _install_helm_components(components)
+    _install_helm_components(components, repos)
 
 
 def _load_local_repos(paths: Sequence[Path]) -> tuple[LocalRepo, ...]:
@@ -216,9 +216,76 @@ def _add_helm_repos(components: ClusterComponents) -> None:
         helm("repo", "update")
 
 
-def _install_helm_components(components: ClusterComponents) -> None:
+def _local_repos_overlay(local_repos: Sequence[LocalRepo]) -> dict[str, Any]:
+    """Helm values that expose --local-repo mounts to Argo CD.
+
+    kind extraMounts put the repos on workers under LOCAL_REPO_MOUNT_ROOT.
+    We hostPath that dir into repo-server, register each as a file:// git
+    repo, and set safe.directory=* so git accepts the bind-mounted ownership.
+    Affinity keeps repo-server off the control-plane, which has no mounts.
+    """
+    if not local_repos:
+        return {}
+
+    repositories = {
+        f"local-{repo.basename}": {
+            "name": repo.basename,
+            "type": "git",
+            "url": f"file://{repo.container_path}",
+        }
+        for repo in local_repos
+    }
+    return {
+        "configs": {"repositories": repositories},
+        "repoServer": {
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "node-role.kubernetes.io/control-plane",
+                                        "operator": "DoesNotExist",
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "env": [
+                {"name": "GIT_CONFIG_COUNT", "value": "1"},
+                {"name": "GIT_CONFIG_KEY_0", "value": "safe.directory"},
+                {"name": "GIT_CONFIG_VALUE_0", "value": "*"},
+            ],
+            "volumeMounts": [
+                {
+                    "name": "local-repos",
+                    "mountPath": LOCAL_REPO_MOUNT_ROOT,
+                    "readOnly": True,
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "local-repos",
+                    "hostPath": {
+                        "path": LOCAL_REPO_MOUNT_ROOT,
+                        "type": "Directory",
+                    },
+                }
+            ],
+        },
+    }
+
+
+def _install_helm_components(
+    components: ClusterComponents,
+    local_repos: Sequence[LocalRepo] = (),
+) -> None:
     list_out = helm("list", "--all-namespaces", "--deployed", "-q", capture_stdout=True)
     installed = list_out.stdout.splitlines()
+    local_repos_overlay = _local_repos_overlay(local_repos)
     LOG.info("Installing cluster components")
     for desired in components.cluster_components:
         if desired.name in installed:
@@ -243,6 +310,13 @@ def _install_helm_components(components: ClusterComponents) -> None:
                         encoding="utf-8",
                     )
                     install_args.extend(["-f", str(values_path)])
+                if desired.local_repo_integration == "argo-cd" and local_repos_overlay:
+                    overlay_path = Path(tmpdir) / "local-repos-overlay.yaml"
+                    overlay_path.write_text(
+                        yaml.safe_dump(local_repos_overlay, default_flow_style=False),
+                        encoding="utf-8",
+                    )
+                    install_args.extend(["-f", str(overlay_path)])
                 helm(*install_args)
 
 

--- a/zep-dev/src/zep_dev/cluster.py
+++ b/zep-dev/src/zep_dev/cluster.py
@@ -5,6 +5,8 @@ from contextlib import contextmanager, nullcontext
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import yaml
+
 from zep_dev.models import ClusterComponents
 from zep_dev.shared import CommandResult, execute
 
@@ -86,20 +88,26 @@ def _install_helm_components(components: ClusterComponents) -> None:
         if desired.name in installed:
             LOG.info("Skipping already installed chart: %s", desired.name)
         else:
-            install_args: list[str] = [
-                "install",
-                desired.name,
-                desired.chart,
-                "--namespace",
-                desired.namespace,
-                "--create-namespace",
-                "--version",
-                desired.version,
-                "--wait",
-            ]
-            for key, value in desired.set.items():
-                install_args.extend(["--set", f"{key}={value}"])
-            helm(*install_args)
+            with TemporaryDirectory() as tmpdir:
+                install_args: list[str] = [
+                    "install",
+                    desired.name,
+                    desired.chart,
+                    "--namespace",
+                    desired.namespace,
+                    "--create-namespace",
+                    "--version",
+                    desired.version,
+                    "--wait",
+                ]
+                if desired.values:
+                    values_path = Path(tmpdir) / "values.yaml"
+                    values_path.write_text(
+                        yaml.safe_dump(desired.values, default_flow_style=False),
+                        encoding="utf-8",
+                    )
+                    install_args.extend(["-f", str(values_path)])
+                helm(*install_args)
 
 
 def teardown_cluster() -> None:

--- a/zep-dev/src/zep_dev/commands/cluster/create.py
+++ b/zep-dev/src/zep_dev/commands/cluster/create.py
@@ -5,7 +5,7 @@ import click
 
 from zep_dev import cluster
 from zep_dev.cluster import KUBECONF_PATH
-from zep_dev.models import ClusterComponents
+from zep_dev.models import LOCAL_REPO_MOUNT_ROOT, ClusterComponents
 
 
 @click.command("create")
@@ -16,10 +16,30 @@ from zep_dev.models import ClusterComponents
     help="Path to kind cluster config YAML",
 )
 @click.option("--components", type=click.File("r"), required=True)
-def create(kind_config: Path, components: TextIOWrapper) -> None:
+@click.option(
+    "--local-repo",
+    "local_repos",
+    multiple=True,
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        path_type=Path,
+    ),
+    help=(
+        "Local Git repository to bind-mount into kind workers at "
+        f"{LOCAL_REPO_MOUNT_ROOT}/<basename>. Repeatable."
+    ),
+)
+def create(
+    kind_config: Path,
+    components: TextIOWrapper,
+    local_repos: tuple[Path, ...],
+) -> None:
     cluster.create_cluster(
         kind_config,
         components=ClusterComponents.from_text_io(components),
+        local_repos=local_repos,
     )
     click.echo("Cluster created. Execute:")
     click.echo(f"    export KUBECONFIG={KUBECONF_PATH}")

--- a/zep-dev/src/zep_dev/models.py
+++ b/zep-dev/src/zep_dev/models.py
@@ -30,6 +30,7 @@ class ClusterComponent(BaseModel):
     chart: str
     version: str
     namespace: str
+    local_repo_integration: Literal["argo-cd"] | None = None
     values: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/zep-dev/src/zep_dev/models.py
+++ b/zep-dev/src/zep_dev/models.py
@@ -13,7 +13,7 @@ class ClusterComponent(BaseModel):
     chart: str
     version: str
     namespace: str
-    set: dict[str, str] = Field(default_factory=dict)
+    values: dict[str, Any] = Field(default_factory=dict)
 
 
 class RequiredTool(BaseModel):

--- a/zep-dev/src/zep_dev/models.py
+++ b/zep-dev/src/zep_dev/models.py
@@ -1,10 +1,27 @@
 import os
 from contextlib import suppress
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Self, TextIO
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field
+
+# Path inside kind workers. Argo file:// URLs and repo-server hostPath both assume it.
+LOCAL_REPO_MOUNT_ROOT = "/mnt/local-repos"
+
+
+@dataclass(frozen=True)
+class LocalRepo:
+    path: Path
+
+    @property
+    def basename(self) -> str:
+        return self.path.name
+
+    @property
+    def container_path(self) -> str:
+        return f"{LOCAL_REPO_MOUNT_ROOT}/{self.basename}"
 
 
 class ClusterComponent(BaseModel):

--- a/zep-dev/tests/_fake_execute.py
+++ b/zep-dev/tests/_fake_execute.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import call
 
 from zep_dev.shared import CommandResult
+
+ExecuteHook = Callable[[tuple[str, ...], dict[str, object]], None]
 
 
 @dataclass
@@ -13,6 +16,7 @@ class _Rule:
     prefix: tuple[str, ...]
     result: CommandResult
     raises: BaseException | None = None
+    hook: ExecuteHook | None = None
 
     def matches(self, args: tuple[str, ...]) -> bool:
         return args[: len(self.prefix)] == self.prefix
@@ -30,9 +34,15 @@ class FakeExecute:
         stderr: str = "",
         returncode: int = 0,
         raises: BaseException | None = None,
+        hook: ExecuteHook | None = None,
     ) -> FakeExecute:
         self._rules.append(
-            _Rule(prefix, CommandResult(returncode, stdout, stderr), raises)
+            _Rule(
+                prefix=prefix,
+                result=CommandResult(returncode, stdout, stderr),
+                raises=raises,
+                hook=hook,
+            )
         )
         return self
 
@@ -43,7 +53,7 @@ class FakeExecute:
         self.calls.append(call(*args, **kwargs))
         for rule in self._rules:
             if rule.matches(args):
-                result, raises = rule.result, rule.raises
+                result, raises, hook = rule.result, rule.raises, rule.hook
                 break
         else:
             prefixes = [rule.prefix for rule in self._rules]
@@ -51,6 +61,8 @@ class FakeExecute:
                 f"No rule matched execute{args!r} with {kwargs!r}; "
                 f"configured prefixes: {prefixes!r}"
             )
+        if hook is not None:
+            hook(args, kwargs)
         if raises is not None:
             raise raises
         if kwargs.get("check", True) and result.returncode != 0:

--- a/zep-dev/tests/test_chart_metadata.py
+++ b/zep-dev/tests/test_chart_metadata.py
@@ -8,7 +8,7 @@ from zep_dev.cli import cli
 
 
 def test_metadata_full_fields(tmp_path: Path) -> None:
-    chart_yaml = {
+    chart_yaml: dict[str, object] = {
         "name": "mychart",
         "version": "1.2.3",
         "type": "library",

--- a/zep-dev/tests/test_zep_dev.py
+++ b/zep-dev/tests/test_zep_dev.py
@@ -1,16 +1,21 @@
 import os
+from collections.abc import Callable
 from io import StringIO
+from itertools import pairwise
 from pathlib import Path
+from types import ModuleType
 
 import pytest
+import yaml
 from pydantic import ValidationError
 
+from _fake_execute import FakeExecute
 from zep_dev import cluster
 from zep_dev.cluster import (
     KUBECONF_PATH,
     kube_guard,
 )
-from zep_dev.models import ClusterComponents
+from zep_dev.models import ClusterComponent, ClusterComponents, LocalRepo
 
 EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
 
@@ -23,13 +28,12 @@ def test_examples_components_yaml_parses() -> None:
     assert components.helm_repos == {
         "argo": "https://argoproj.github.io/argo-helm",
     }
-    assert len(components.cluster_components) == 1
-
-    argo_cd = components.cluster_components[0]
+    [argo_cd] = components.cluster_components
     assert argo_cd.name == "argo-cd"
     assert argo_cd.chart == "argo/argo-cd"
     assert argo_cd.version == "9.5.0"
     assert argo_cd.namespace == "argo-cd"
+    assert argo_cd.local_repo_integration == "argo-cd"
     assert argo_cd.values["server"]["service"]["type"] == "NodePort"
     assert argo_cd.values["configs"]["cm"]["admin.enabled"] is True
     assert argo_cd.values["dex"]["enabled"] is False
@@ -82,3 +86,101 @@ def test_add_helm_repos_skips_all_helm_when_no_repos_configured(
     cluster._add_helm_repos(
         ClusterComponents(helm_repos={}, cluster_components=[]),
     )
+
+
+def test_install_helm_components_applies_local_repo_integration_only_to_selected_component(
+    fake_execute: Callable[[ModuleType], FakeExecute],
+    tmp_path: Path,
+) -> None:
+    installed_values: dict[str, list[object]] = {}
+
+    def capture_values(args: tuple[str, ...], kwargs: dict[str, object]) -> None:
+        _, _, release, *_ = args
+        value_paths = [Path(value) for flag, value in pairwise(args) if flag == "-f"]
+        installed_values[release] = [
+            yaml.safe_load(path.read_text(encoding="utf-8")) for path in value_paths
+        ]
+
+    fake = fake_execute(cluster)
+    fake.on("helm", "list", stdout="")
+    fake.on("helm", "install", "argo", hook=capture_values)
+    fake.on("helm", "install", "other", hook=capture_values)
+    components = ClusterComponents(
+        helm_repos={},
+        cluster_components=[
+            ClusterComponent(
+                name="argo",
+                chart="example/argo",
+                version="1.0.0",
+                namespace="argo",
+                local_repo_integration="argo-cd",
+                values={"base": "argo"},
+            ),
+            ClusterComponent(
+                name="other",
+                chart="example/other",
+                version="1.0.0",
+                namespace="other",
+                values={"base": "other"},
+            ),
+        ],
+    )
+
+    cluster._install_helm_components(
+        components,
+        local_repos=[LocalRepo(path=tmp_path / "deployments")],
+    )
+
+    assert installed_values["other"] == [{"base": "other"}]
+    base_values, overlay = installed_values["argo"]
+    assert base_values == {"base": "argo"}
+    assert overlay == {
+        "configs": {
+            "repositories": {
+                "local-deployments": {
+                    "name": "deployments",
+                    "type": "git",
+                    "url": "file:///mnt/local-repos/deployments",
+                }
+            }
+        },
+        "repoServer": {
+            "affinity": {
+                "nodeAffinity": {
+                    "requiredDuringSchedulingIgnoredDuringExecution": {
+                        "nodeSelectorTerms": [
+                            {
+                                "matchExpressions": [
+                                    {
+                                        "key": "node-role.kubernetes.io/control-plane",
+                                        "operator": "DoesNotExist",
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            },
+            "env": [
+                {"name": "GIT_CONFIG_COUNT", "value": "1"},
+                {"name": "GIT_CONFIG_KEY_0", "value": "safe.directory"},
+                {"name": "GIT_CONFIG_VALUE_0", "value": "*"},
+            ],
+            "volumeMounts": [
+                {
+                    "mountPath": "/mnt/local-repos",
+                    "name": "local-repos",
+                    "readOnly": True,
+                }
+            ],
+            "volumes": [
+                {
+                    "hostPath": {
+                        "path": "/mnt/local-repos",
+                        "type": "Directory",
+                    },
+                    "name": "local-repos",
+                }
+            ],
+        },
+    }

--- a/zep-dev/tests/test_zep_dev.py
+++ b/zep-dev/tests/test_zep_dev.py
@@ -21,28 +21,30 @@ def test_examples_components_yaml_parses() -> None:
     )
 
     assert components.helm_repos == {
-        "argocd": "https://argoproj.github.io/argo-helm",
+        "argo": "https://argoproj.github.io/argo-helm",
     }
     assert len(components.cluster_components) == 1
 
-    argocd = components.cluster_components[0]
-    assert argocd.name == "argocd"
-    assert argocd.chart == "argocd/argo-cd"
-    assert argocd.version == "10.0.1"
-    assert argocd.namespace == "argocd"
-    assert argocd.set["server.service.type"] == "NodePort"
+    argo_cd = components.cluster_components[0]
+    assert argo_cd.name == "argo-cd"
+    assert argo_cd.chart == "argo/argo-cd"
+    assert argo_cd.version == "9.5.0"
+    assert argo_cd.namespace == "argo-cd"
+    assert argo_cd.values["server"]["service"]["type"] == "NodePort"
+    assert argo_cd.values["configs"]["cm"]["admin.enabled"] is True
+    assert argo_cd.values["dex"]["enabled"] is False
 
 
 def test_empty_cluster_components_valid() -> None:
     yaml_input = """\
 helm_repos:
-  argocd: "https://argoproj.github.io/argo-helm"
+  argo: "https://argoproj.github.io/argo-helm"
 cluster_components: []
 """
     components = ClusterComponents.from_text_io(StringIO(yaml_input))
 
     assert components.helm_repos == {
-        "argocd": "https://argoproj.github.io/argo-helm",
+        "argo": "https://argoproj.github.io/argo-helm",
     }
     assert components.cluster_components == []
 


### PR DESCRIPTION
Implement support for creating a kind cluster with --local-repos, and configuring Argo to use them. This required some refactoring of `cluster_components`: we did away with using set command line flags, and instead inline the values directly. Additionally, we added the concept of "local_repo_integration", with initial support only for argo-cd. This is used to wire up argo on installation with the repos we passed on the command line.

Creating a cluster prior to this commit was idempotent, and it just did nothing if the cluster already existed. We've changed this somewhat, as repos are mounted at cluster create time by injecting into the config. To prevent the case where someone adds a different --local-repo and then is like wtf where is my repo bro, we `podman` inspect the running cluster, extract the mounts and only continue if they are exactly the same. We assume podman exists on the developer machines. Not sure if that is a fair assumption or not.

See commit messages for additional info.