### PR TITLE
Add zep-dev secret create command

### DIFF
--- a/zep-dev/src/zep_dev/cli.py
+++ b/zep-dev/src/zep_dev/cli.py
@@ -5,6 +5,7 @@ import click
 
 from zep_dev.groups.chart import chart
 from zep_dev.groups.cluster import cluster
+from zep_dev.groups.secrets import secrets
 from zep_dev.groups.tools import tools
 from zep_dev.shared import get_bin_dir
 
@@ -40,3 +41,4 @@ def configure_logging(verbose: int) -> None:
 cli.add_command(cluster)
 cli.add_command(tools)
 cli.add_command(chart)
+cli.add_command(secrets)

--- a/zep-dev/src/zep_dev/commands/chart/test.py
+++ b/zep-dev/src/zep_dev/commands/chart/test.py
@@ -8,15 +8,11 @@ import yaml
 from click import ClickException
 from pydantic import ValidationError
 
+from zep_dev.cluster import kubectl
+from zep_dev.k8s_secrets import create_image_pull_secret, secret_exists
 from zep_dev.models import ChartMetadata, CiSecrets
 from zep_dev.shared import ResolvedChart, execute, resolve_chart
 from zep_dev.static import CI_SECRETS_YAML, CT_YAML
-
-IMAGE_SECRET_PATHS = [
-    Path("~/.config/containers/auth.json").expanduser(),
-    Path("~/.docker/config.json").expanduser(),
-]
-IMAGE_SECRET_NAME = "github-registry"
 
 LOG = logging.getLogger(__name__)
 
@@ -90,13 +86,13 @@ def create_test_namespace(ct_yaml_path: Path) -> str:
     test_namespace: str | None = ct_yaml.get("namespace")
     if test_namespace is None:
         raise ClickException(f"namespace must be specified in {CT_YAML}")
-    namespaces = execute("kubectl", "get", "namespaces", capture_stdout=True)
+    namespaces = kubectl("get", "namespaces", capture_stdout=True)
     for line in namespaces.stdout.splitlines():
         ns, *_ = line.split()
         if ns == test_namespace:
             break
     else:
-        execute("kubectl", "create", "namespace", test_namespace)
+        kubectl("create", "namespace", test_namespace)
     return test_namespace
 
 
@@ -124,8 +120,7 @@ def create_additional_secrets(namespace: str) -> None:
                     f"points to non-existent path: {secret_path}"
                 )
             if not secret_exists(namespace=namespace, secret_name=secret.name):
-                execute(
-                    "kubectl",
+                kubectl(
                     f"--namespace={namespace}",
                     "create",
                     "secret",
@@ -133,44 +128,6 @@ def create_additional_secrets(namespace: str) -> None:
                     secret.name,
                     f"--from-env-file={secret_path}",
                 )
-
-
-def create_image_pull_secret(namespace: str) -> None:
-    LOG.info("Creating imagePullSecret")
-    auth_json_path = next((path for path in IMAGE_SECRET_PATHS if path.exists()), None)
-    if auth_json_path is None:
-        raise ClickException(
-            f"Failed to locate auth.json to populate {IMAGE_SECRET_NAME} "
-            f"at paths: {IMAGE_SECRET_PATHS}"
-        )
-
-    if not secret_exists(namespace=namespace, secret_name=IMAGE_SECRET_NAME):
-        execute(
-            "kubectl",
-            "create",
-            "secret",
-            "generic",
-            IMAGE_SECRET_NAME,
-            f"--namespace={namespace}",
-            f"--from-file=.dockerconfigjson={auth_json_path}",
-            "--type=kubernetes.io/dockerconfigjson",
-        )
-
-
-def secret_exists(namespace: str, secret_name: str) -> bool:
-    existing_secrets = execute(
-        "kubectl",
-        "get",
-        "secrets",
-        f"--namespace={namespace}",
-        "--no-headers",
-        capture_stdout=True,
-    )
-    for line in existing_secrets.stdout.splitlines():
-        existing_secret, *_ = line.split()
-        if existing_secret == secret_name:
-            return True
-    return False
 
 
 def execute_lint_and_install(

--- a/zep-dev/src/zep_dev/commands/secrets/create.py
+++ b/zep-dev/src/zep_dev/commands/secrets/create.py
@@ -1,0 +1,13 @@
+import click
+
+from zep_dev.k8s_secrets import create_image_pull_secret
+
+
+@click.command("create")
+@click.option(
+    "--namespace",
+    required=True,
+    help="Namespace in which to create the github-registry image-pull Secret",
+)
+def create(namespace: str) -> None:
+    create_image_pull_secret(namespace)

--- a/zep-dev/src/zep_dev/groups/secrets.py
+++ b/zep-dev/src/zep_dev/groups/secrets.py
@@ -1,0 +1,11 @@
+import click
+
+from zep_dev.commands.secrets.create import create
+
+
+@click.group("secrets", help="Manage Kubernetes Secrets for local kind testing")
+def secrets() -> None:
+    pass
+
+
+secrets.add_command(create)

--- a/zep-dev/src/zep_dev/k8s_secrets.py
+++ b/zep-dev/src/zep_dev/k8s_secrets.py
@@ -1,0 +1,50 @@
+import logging
+from pathlib import Path
+
+from click import ClickException
+
+from zep_dev.cluster import kubectl
+
+IMAGE_SECRET_PATHS = [
+    Path("~/.config/containers/auth.json").expanduser(),
+    Path("~/.docker/config.json").expanduser(),
+]
+IMAGE_SECRET_NAME = "github-registry"
+
+LOG = logging.getLogger(__name__)
+
+
+def create_image_pull_secret(namespace: str) -> None:
+    LOG.info("Creating imagePullSecret")
+    auth_json_path = next((path for path in IMAGE_SECRET_PATHS if path.exists()), None)
+    if auth_json_path is None:
+        raise ClickException(
+            f"Failed to locate auth.json to populate {IMAGE_SECRET_NAME} "
+            f"at paths: {IMAGE_SECRET_PATHS}"
+        )
+
+    if not secret_exists(namespace=namespace, secret_name=IMAGE_SECRET_NAME):
+        kubectl(
+            "create",
+            "secret",
+            "generic",
+            IMAGE_SECRET_NAME,
+            f"--namespace={namespace}",
+            f"--from-file=.dockerconfigjson={auth_json_path}",
+            "--type=kubernetes.io/dockerconfigjson",
+        )
+
+
+def secret_exists(namespace: str, secret_name: str) -> bool:
+    existing_secrets = kubectl(
+        "get",
+        "secrets",
+        f"--namespace={namespace}",
+        "--no-headers",
+        capture_stdout=True,
+    )
+    for line in existing_secrets.stdout.splitlines():
+        existing_secret, *_ = line.split()
+        if existing_secret == secret_name:
+            return True
+    return False

--- a/zep-dev/tests/conftest.py
+++ b/zep-dev/tests/conftest.py
@@ -5,6 +5,7 @@ from types import ModuleType
 import pytest
 
 from _fake_execute import FakeExecute
+from zep_dev import k8s_secrets
 
 
 @pytest.fixture
@@ -17,6 +18,14 @@ def fake_execute(
         return fake
 
     return _install
+
+
+@pytest.fixture
+def auth_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    path = tmp_path / "auth.json"
+    path.write_text("{}\n")
+    monkeypatch.setattr(k8s_secrets, "IMAGE_SECRET_PATHS", [path])
+    return path
 
 
 @pytest.fixture

--- a/zep-dev/tests/test_chart_test.py
+++ b/zep-dev/tests/test_chart_test.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
 from unittest.mock import call
@@ -8,8 +9,15 @@ from click.testing import CliRunner
 
 from _charts import write_chart
 from _fake_execute import FakeExecute
+from zep_dev import k8s_secrets
 from zep_dev.cli import cli
 from zep_dev.commands.chart import test as test_module
+
+
+@dataclass(frozen=True)
+class ChartTestFakes:
+    kubectl: FakeExecute
+    execute: FakeExecute
 
 
 def _write_chart(
@@ -21,21 +29,21 @@ def _write_chart(
     return write_chart(helm_dir / "charts" / chart_dir_name, chart_yaml)
 
 
-@pytest.fixture
-def patched_image_secret(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    auth_json = tmp_path / "auth.json"
-    auth_json.write_text("{}\n")
-    monkeypatch.setattr(test_module, "IMAGE_SECRET_PATHS", [auth_json])
-
-
-def _install_chart_execute(
+def _install_chart_fakes(
     fake_execute: Callable[[ModuleType], FakeExecute],
-) -> FakeExecute:
-    return (
-        fake_execute(test_module)
-        .on("kubectl", "get", "namespaces", stdout="test-ns\n")
-        .on("kubectl", "get", "secrets")
-        .on("kubectl", "create", "secret")
+    monkeypatch: pytest.MonkeyPatch,
+) -> ChartTestFakes:
+    kubectl_fake = (
+        FakeExecute()
+        .on("get", "namespaces", stdout="test-ns\n")
+        .on("get", "secrets")
+        .on("create", "secret")
+    )
+    monkeypatch.setattr(test_module, "kubectl", kubectl_fake)
+    monkeypatch.setattr(k8s_secrets, "kubectl", kubectl_fake)
+    return ChartTestFakes(
+        kubectl=kubectl_fake,
+        execute=fake_execute(test_module),
     )
 
 
@@ -55,11 +63,12 @@ def test_test_missing_ct_yaml_fails(tmp_path: Path) -> None:
 
 def test_library_chart_skips_install(
     helm_dir: Path,
-    patched_image_secret: None,
+    auth_json: Path,
     fake_execute: Callable[[ModuleType], FakeExecute],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     chart_dir = _write_chart(helm_dir, "mylib", chart_type="library")
-    fake = _install_chart_execute(fake_execute)
+    fakes = _install_chart_fakes(fake_execute, monkeypatch)
 
     result = CliRunner().invoke(
         cli, ["chart", "test", "--helm-dir", str(helm_dir), "--chart", str(chart_dir)]
@@ -67,19 +76,19 @@ def test_library_chart_skips_install(
 
     assert result.exit_code == 0, result.output
     assert "Skipping install" in result.output
-    assert fake.calls_for("ct") == []
+    assert fakes.execute.calls_for("ct") == []
 
 
 def test_application_chart_runs_lint_and_install(
     tmp_path: Path,
     helm_dir: Path,
-    patched_image_secret: None,
+    auth_json: Path,
     fake_execute: Callable[[ModuleType], FakeExecute],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _write_chart(helm_dir, "myapp")
-    fake = _install_chart_execute(fake_execute)
-    fake.on("ct", "lint-and-install")
+    fakes = _install_chart_fakes(fake_execute, monkeypatch)
+    fakes.execute.on("ct", "lint-and-install")
 
     # Mirrors the real workflow contract: invoked from repo root with the
     # repo-root-relative path that `chart list-changed` would emit.
@@ -90,7 +99,7 @@ def test_application_chart_runs_lint_and_install(
     )
 
     assert result.exit_code == 0, result.output
-    assert fake.calls_for("ct")[-1] == call(
+    assert fakes.execute.calls_for("ct")[-1] == call(
         "ct",
         "lint-and-install",
         "--config",
@@ -103,12 +112,13 @@ def test_application_chart_runs_lint_and_install(
 
 def test_application_chart_lint_and_install_failure_raises(
     helm_dir: Path,
-    patched_image_secret: None,
+    auth_json: Path,
     fake_execute: Callable[[ModuleType], FakeExecute],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     chart_dir = _write_chart(helm_dir, "myapp")
-    fake = _install_chart_execute(fake_execute)
-    fake.on("ct", "lint-and-install", returncode=3)
+    fakes = _install_chart_fakes(fake_execute, monkeypatch)
+    fakes.execute.on("ct", "lint-and-install", returncode=3)
 
     result = CliRunner().invoke(
         cli, ["chart", "test", "--helm-dir", str(helm_dir), "--chart", str(chart_dir)]
@@ -121,8 +131,6 @@ def test_application_chart_lint_and_install_failure_raises(
 def test_chart_outside_helm_dir_fails(
     tmp_path: Path,
     helm_dir: Path,
-    patched_image_secret: None,
-    fake_execute: Callable[[ModuleType], FakeExecute],
 ) -> None:
     outside_chart = _write_chart(tmp_path / "other", "myapp")
 
@@ -137,25 +145,26 @@ def test_chart_outside_helm_dir_fails(
 
 def test_discovery_mode_processes_all_charts_and_skips_libraries(
     helm_dir: Path,
-    patched_image_secret: None,
+    auth_json: Path,
     fake_execute: Callable[[ModuleType], FakeExecute],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _write_chart(helm_dir, "app-a")
     _write_chart(helm_dir, "app-b")
     _write_chart(helm_dir, "lib-a", chart_type="library")
-    fake = _install_chart_execute(fake_execute)
-    fake.on("ct", "lint-and-install")
+    fakes = _install_chart_fakes(fake_execute, monkeypatch)
+    fakes.execute.on("ct", "lint-and-install")
 
     result = CliRunner().invoke(cli, ["chart", "test", "--helm-dir", str(helm_dir)])
 
     assert result.exit_code == 0, result.output
     assert "Skipping install" in result.output
 
-    assert len(fake.calls_for("kubectl", "get", "namespaces")) == 1, (
+    assert len(fakes.kubectl.calls_for("get", "namespaces")) == 1, (
         "namespace/secret setup must run once, not per chart"
     )
 
-    assert fake.calls_for("ct") == [
+    assert fakes.execute.calls_for("ct") == [
         call(
             "ct",
             "lint-and-install",

--- a/zep-dev/tests/test_secrets.py
+++ b/zep-dev/tests/test_secrets.py
@@ -1,0 +1,78 @@
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+from unittest.mock import call
+
+import pytest
+from click.testing import CliRunner
+
+from _fake_execute import FakeExecute
+from zep_dev import k8s_secrets
+from zep_dev.cli import cli
+from zep_dev.k8s_secrets import IMAGE_SECRET_NAME
+
+
+@pytest.fixture
+def fake_kubectl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[ModuleType], FakeExecute]:
+    def _install(module: ModuleType) -> FakeExecute:
+        fake = FakeExecute()
+        monkeypatch.setattr(module, "kubectl", fake)
+        return fake
+
+    return _install
+
+
+def test_secrets_create_when_absent(
+    auth_json: Path,
+    fake_kubectl: Callable[[ModuleType], FakeExecute],
+) -> None:
+    fake = (
+        fake_kubectl(k8s_secrets).on("get", "secrets", stdout="").on("create", "secret")
+    )
+
+    result = CliRunner().invoke(cli, ["secrets", "create", "--namespace", "test-ns"])
+
+    assert result.exit_code == 0, result.output
+    assert fake.calls_for("create", "secret") == [
+        call(
+            "create",
+            "secret",
+            "generic",
+            IMAGE_SECRET_NAME,
+            "--namespace=test-ns",
+            f"--from-file=.dockerconfigjson={auth_json}",
+            "--type=kubernetes.io/dockerconfigjson",
+        )
+    ]
+
+
+def test_secrets_create_skips_when_present(
+    auth_json: Path,
+    fake_kubectl: Callable[[ModuleType], FakeExecute],
+) -> None:
+    fake = fake_kubectl(k8s_secrets).on(
+        "get",
+        "secrets",
+        stdout=f"{IMAGE_SECRET_NAME}   Opaque   1   1s\n",
+    )
+
+    result = CliRunner().invoke(cli, ["secrets", "create", "--namespace", "test-ns"])
+
+    assert result.exit_code == 0, result.output
+    assert fake.calls_for("create", "secret") == []
+
+
+def test_secrets_create_fails_without_auth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    fake_kubectl: FakeExecute,
+) -> None:
+    missing = tmp_path / "missing-auth.json"
+    monkeypatch.setattr(k8s_secrets, "IMAGE_SECRET_PATHS", [missing])
+
+    result = CliRunner().invoke(cli, ["secrets", "create", "--namespace", "test-ns"])
+
+    assert result.exit_code != 0
+    assert "Failed to locate auth.json" in result.output


### PR DESCRIPTION
Add a command for creating our image pull secrets in a namespace. This
will be used in other tooling, namely the chainsaw tests in the
deployments repo. Centralizing this functionality in a single command
prevents duplicating it in other places.

Signed-off-by: William Coe <william.coe@zepben.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>