### PR TITLE
Add k8s.py helper module

### DIFF
--- a/zep-dev/src/zep_dev/cluster.py
+++ b/zep-dev/src/zep_dev/cluster.py
@@ -1,8 +1,7 @@
 import json
 import logging
-import os
-from collections.abc import Generator, Sequence
-from contextlib import contextmanager, nullcontext
+from collections.abc import Sequence
+from contextlib import nullcontext
 from pathlib import Path
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
@@ -11,6 +10,7 @@ from typing import Any
 import yaml
 from click import ClickException
 
+from zep_dev.k8s import KUBECONF_PATH, kube_guard, kubectl
 from zep_dev.models import (
     LOCAL_REPO_MOUNT_ROOT,
     ClusterComponents,
@@ -19,27 +19,7 @@ from zep_dev.models import (
 from zep_dev.shared import CommandResult, execute
 
 CLUSTER_NAME = "test-cluster"
-
-# Write this to a file in /tmp to avoid clashes with whatever the
-# user may have configured. Also is a safety issue, don't want to
-# accidentlly target production clusters
-KUBECONF_PATH = Path("/tmp/kind-k8s-conf.yaml")
 LOG = logging.getLogger(__name__)
-
-
-@contextmanager
-def kube_guard() -> Generator[None]:
-    """
-    Ensure when we run commands, we are using our kind KUBECONFIG.
-    This is to prevent accidentally a production cluster.
-    """
-    og_conf = os.environ.get("KUBECONFIG")
-    os.environ["KUBECONFIG"] = str(KUBECONF_PATH)
-    yield
-    if og_conf is not None:
-        os.environ["KUBECONFIG"] = og_conf
-    else:
-        os.environ.pop("KUBECONFIG", None)
 
 
 def create_cluster(
@@ -376,8 +356,3 @@ def podman(*args: str, capture_stdout: bool = False) -> CommandResult:
 def helm(*args: str, capture_stdout: bool = False) -> CommandResult:
     with kube_guard():
         return execute("helm", *args, capture_stdout=capture_stdout)
-
-
-def kubectl(*args: str, capture_stdout: bool = False) -> CommandResult:
-    with kube_guard():
-        return execute("kubectl", *args, capture_stdout=capture_stdout)

--- a/zep-dev/src/zep_dev/commands/chart/test.py
+++ b/zep-dev/src/zep_dev/commands/chart/test.py
@@ -8,8 +8,8 @@ import yaml
 from click import ClickException
 from pydantic import ValidationError
 
-from zep_dev.cluster import kubectl
-from zep_dev.k8s_secrets import create_image_pull_secret, secret_exists
+from zep_dev.k8s import kubectl, resource_exists
+from zep_dev.k8s_secrets import create_image_pull_secret
 from zep_dev.models import ChartMetadata, CiSecrets
 from zep_dev.shared import ResolvedChart, execute, resolve_chart
 from zep_dev.static import CI_SECRETS_YAML, CT_YAML
@@ -86,12 +86,7 @@ def create_test_namespace(ct_yaml_path: Path) -> str:
     test_namespace: str | None = ct_yaml.get("namespace")
     if test_namespace is None:
         raise ClickException(f"namespace must be specified in {CT_YAML}")
-    namespaces = kubectl("get", "namespaces", capture_stdout=True)
-    for line in namespaces.stdout.splitlines():
-        ns, *_ = line.split()
-        if ns == test_namespace:
-            break
-    else:
+    if not resource_exists("namespace", test_namespace):
         kubectl("create", "namespace", test_namespace)
     return test_namespace
 
@@ -119,7 +114,7 @@ def create_additional_secrets(namespace: str) -> None:
                     f"Secret {secret.name}:{secret.env_var} "
                     f"points to non-existent path: {secret_path}"
                 )
-            if not secret_exists(namespace=namespace, secret_name=secret.name):
+            if not resource_exists("secret", secret.name, namespace=namespace):
                 kubectl(
                     f"--namespace={namespace}",
                     "create",

--- a/zep-dev/src/zep_dev/commands/cluster/create.py
+++ b/zep-dev/src/zep_dev/commands/cluster/create.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import click
 
 from zep_dev import cluster
-from zep_dev.cluster import KUBECONF_PATH
+from zep_dev.k8s import KUBECONF_PATH
 from zep_dev.models import LOCAL_REPO_MOUNT_ROOT, ClusterComponents
 
 

--- a/zep-dev/src/zep_dev/k8s.py
+++ b/zep-dev/src/zep_dev/k8s.py
@@ -1,0 +1,48 @@
+import os
+from collections.abc import Generator
+from contextlib import contextmanager
+from pathlib import Path
+
+from zep_dev.shared import CommandResult, execute
+
+KUBECONF_PATH = Path("/tmp/kind-k8s-conf.yaml")
+
+
+@contextmanager
+def kube_guard() -> Generator[None]:
+    """
+    Ensure when we run commands, we are using our kind KUBECONFIG.
+    This is to prevent accidentally targeting production clusters.
+    """
+    og_conf = os.environ.get("KUBECONFIG")
+    os.environ["KUBECONFIG"] = str(KUBECONF_PATH)
+    yield
+    if og_conf is not None:
+        os.environ["KUBECONFIG"] = og_conf
+    else:
+        os.environ.pop("KUBECONFIG", None)
+
+
+def kubectl(*args: str, capture_stdout: bool = False) -> CommandResult:
+    with kube_guard():
+        return execute("kubectl", *args, capture_stdout=capture_stdout)
+
+
+def resource_exists(
+    resource: str,
+    name: str,
+    *,
+    namespace: str | None = None,
+) -> bool:
+    args = [
+        "get",
+        resource,
+        name,
+        "--ignore-not-found",
+        "--output=name",
+    ]
+    if namespace is not None:
+        args.append(f"--namespace={namespace}")
+
+    result = kubectl(*args, capture_stdout=True)
+    return bool(result.stdout.strip())

--- a/zep-dev/src/zep_dev/k8s_secrets.py
+++ b/zep-dev/src/zep_dev/k8s_secrets.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from click import ClickException
 
-from zep_dev.cluster import kubectl
+from zep_dev.k8s import kubectl, resource_exists
 
 IMAGE_SECRET_PATHS = [
     Path("~/.config/containers/auth.json").expanduser(),
@@ -23,7 +23,7 @@ def create_image_pull_secret(namespace: str) -> None:
             f"at paths: {IMAGE_SECRET_PATHS}"
         )
 
-    if not secret_exists(namespace=namespace, secret_name=IMAGE_SECRET_NAME):
+    if not resource_exists("secret", IMAGE_SECRET_NAME, namespace=namespace):
         kubectl(
             "create",
             "secret",
@@ -33,18 +33,3 @@ def create_image_pull_secret(namespace: str) -> None:
             f"--from-file=.dockerconfigjson={auth_json_path}",
             "--type=kubernetes.io/dockerconfigjson",
         )
-
-
-def secret_exists(namespace: str, secret_name: str) -> bool:
-    existing_secrets = kubectl(
-        "get",
-        "secrets",
-        f"--namespace={namespace}",
-        "--no-headers",
-        capture_stdout=True,
-    )
-    for line in existing_secrets.stdout.splitlines():
-        existing_secret, *_ = line.split()
-        if existing_secret == secret_name:
-            return True
-    return False

--- a/zep-dev/tests/test_chart_test.py
+++ b/zep-dev/tests/test_chart_test.py
@@ -9,9 +9,10 @@ from click.testing import CliRunner
 
 from _charts import write_chart
 from _fake_execute import FakeExecute
-from zep_dev import k8s_secrets
+from zep_dev import k8s, k8s_secrets
 from zep_dev.cli import cli
 from zep_dev.commands.chart import test as test_module
+from zep_dev.k8s_secrets import IMAGE_SECRET_NAME
 
 
 @dataclass(frozen=True)
@@ -35,10 +36,11 @@ def _install_chart_fakes(
 ) -> ChartTestFakes:
     kubectl_fake = (
         FakeExecute()
-        .on("get", "namespaces", stdout="test-ns\n")
-        .on("get", "secrets")
+        .on("get", "namespace", "test-ns", stdout="namespace/test-ns\n")
+        .on("get", "secret", IMAGE_SECRET_NAME)
         .on("create", "secret")
     )
+    monkeypatch.setattr(k8s, "kubectl", kubectl_fake)
     monkeypatch.setattr(test_module, "kubectl", kubectl_fake)
     monkeypatch.setattr(k8s_secrets, "kubectl", kubectl_fake)
     return ChartTestFakes(
@@ -160,7 +162,7 @@ def test_discovery_mode_processes_all_charts_and_skips_libraries(
     assert result.exit_code == 0, result.output
     assert "Skipping install" in result.output
 
-    assert len(fakes.kubectl.calls_for("get", "namespaces")) == 1, (
+    assert len(fakes.kubectl.calls_for("get", "namespace", "test-ns")) == 1, (
         "namespace/secret setup must run once, not per chart"
     )
 

--- a/zep-dev/tests/test_k8s.py
+++ b/zep-dev/tests/test_k8s.py
@@ -1,0 +1,91 @@
+import subprocess
+from unittest.mock import call
+
+import pytest
+
+from _fake_execute import FakeExecute
+from zep_dev import k8s
+
+
+@pytest.mark.parametrize(
+    ("resource", "name", "namespace", "stdout", "expected", "expected_call"),
+    [
+        (
+            "secret",
+            "credentials",
+            "test-ns",
+            "secret/credentials\n",
+            True,
+            call(
+                "get",
+                "secret",
+                "credentials",
+                "--ignore-not-found",
+                "--output=name",
+                "--namespace=test-ns",
+                capture_stdout=True,
+            ),
+        ),
+        (
+            "secret",
+            "credentials",
+            "test-ns",
+            "",
+            False,
+            call(
+                "get",
+                "secret",
+                "credentials",
+                "--ignore-not-found",
+                "--output=name",
+                "--namespace=test-ns",
+                capture_stdout=True,
+            ),
+        ),
+        (
+            "namespace",
+            "test-ns",
+            None,
+            "namespace/test-ns\n",
+            True,
+            call(
+                "get",
+                "namespace",
+                "test-ns",
+                "--ignore-not-found",
+                "--output=name",
+                capture_stdout=True,
+            ),
+        ),
+    ],
+)
+def test_resource_exists(
+    monkeypatch: pytest.MonkeyPatch,
+    resource: str,
+    name: str,
+    namespace: str | None,
+    stdout: str,
+    expected: bool,
+    expected_call: object,
+) -> None:
+    fake = FakeExecute().on("get", resource, name, stdout=stdout)
+    monkeypatch.setattr(k8s, "kubectl", fake)
+
+    assert k8s.resource_exists(resource, name, namespace=namespace) is expected
+    assert fake.calls == [expected_call]
+
+
+def test_resource_exists_propagates_kubectl_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = FakeExecute().on(
+        "get",
+        "secret",
+        "credentials",
+        stderr="Forbidden",
+        returncode=1,
+    )
+    monkeypatch.setattr(k8s, "kubectl", fake)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        k8s.resource_exists("secret", "credentials", namespace="test-ns")

--- a/zep-dev/tests/test_secrets.py
+++ b/zep-dev/tests/test_secrets.py
@@ -1,13 +1,11 @@
-from collections.abc import Callable
 from pathlib import Path
-from types import ModuleType
 from unittest.mock import call
 
 import pytest
 from click.testing import CliRunner
 
 from _fake_execute import FakeExecute
-from zep_dev import k8s_secrets
+from zep_dev import k8s, k8s_secrets
 from zep_dev.cli import cli
 from zep_dev.k8s_secrets import IMAGE_SECRET_NAME
 
@@ -15,21 +13,24 @@ from zep_dev.k8s_secrets import IMAGE_SECRET_NAME
 @pytest.fixture
 def fake_kubectl(
     monkeypatch: pytest.MonkeyPatch,
-) -> Callable[[ModuleType], FakeExecute]:
-    def _install(module: ModuleType) -> FakeExecute:
-        fake = FakeExecute()
-        monkeypatch.setattr(module, "kubectl", fake)
-        return fake
-
-    return _install
+) -> FakeExecute:
+    fake = FakeExecute().on(
+        "get",
+        "namespace",
+        "test-ns",
+        stdout="namespace/test-ns\n",
+    )
+    monkeypatch.setattr(k8s, "kubectl", fake)
+    monkeypatch.setattr(k8s_secrets, "kubectl", fake)
+    return fake
 
 
 def test_secrets_create_when_absent(
     auth_json: Path,
-    fake_kubectl: Callable[[ModuleType], FakeExecute],
+    fake_kubectl: FakeExecute,
 ) -> None:
-    fake = (
-        fake_kubectl(k8s_secrets).on("get", "secrets", stdout="").on("create", "secret")
+    fake = fake_kubectl.on("get", "secret", IMAGE_SECRET_NAME, stdout="").on(
+        "create", "secret"
     )
 
     result = CliRunner().invoke(cli, ["secrets", "create", "--namespace", "test-ns"])
@@ -50,12 +51,13 @@ def test_secrets_create_when_absent(
 
 def test_secrets_create_skips_when_present(
     auth_json: Path,
-    fake_kubectl: Callable[[ModuleType], FakeExecute],
+    fake_kubectl: FakeExecute,
 ) -> None:
-    fake = fake_kubectl(k8s_secrets).on(
+    fake = fake_kubectl.on(
         "get",
-        "secrets",
-        stdout=f"{IMAGE_SECRET_NAME}   Opaque   1   1s\n",
+        "secret",
+        IMAGE_SECRET_NAME,
+        stdout=f"secret/{IMAGE_SECRET_NAME}\n",
     )
 
     result = CliRunner().invoke(cli, ["secrets", "create", "--namespace", "test-ns"])

--- a/zep-dev/tests/test_zep_dev.py
+++ b/zep-dev/tests/test_zep_dev.py
@@ -11,7 +11,7 @@ from pydantic import ValidationError
 
 from _fake_execute import FakeExecute
 from zep_dev import cluster
-from zep_dev.cluster import (
+from zep_dev.k8s import (
     KUBECONF_PATH,
     kube_guard,
 )


### PR DESCRIPTION
We were doing a bunch of existance checks in different places in
slightly different ways, which is silly. Write a single helper for
determining if a resource exists in Kubernetes and update all places
where we did resource checks to use it.

Additionally, create a new module that has Kubernetes related helpers in
it. This just helps with discovery and code organisation.

Signed-off-by: William Coe <william.coe@zepben.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>