### PR TITLE
Add Chainsaw and Argo to REQUIRED_TOOLS

### DIFF
--- a/zep-dev/src/zep_dev/static.py
+++ b/zep-dev/src/zep_dev/static.py
@@ -46,6 +46,23 @@ TOOLS: list[RequiredTool] = [
         ),
         archive_member="shellcheck-{version}/shellcheck",
     ),
+    RequiredTool(
+        name="chainsaw",
+        version="0.2.15",
+        url=(
+            "https://github.com/kyverno/chainsaw/releases/download/"
+            "v{version}/chainsaw_linux_amd64.tar.gz"
+        ),
+        archive_member="chainsaw",
+    ),
+    RequiredTool(
+        name="argocd",
+        version="v3.3.6",
+        url=(
+            "https://github.com/argoproj/argo-cd/releases/download/"
+            "{version}/argocd-linux-amd64"
+        ),
+    ),
 ]
 TOOLS_BY_NAME = {tool.name: tool for tool in TOOLS}
 


### PR DESCRIPTION
We need these for the testing on deployments repo. Potentially if this
keeps bloating we may want to add a mechanism to allow a repo to define
the tools it needs, but for now the cost is not too great to just add
them all no matter what.

Signed-off-by: William Coe <william.coe@zepben.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>