### PR TITLE
Configure Argo OCI secrets

### DIFF
--- a/zep-dev/examples/components.yaml
+++ b/zep-dev/examples/components.yaml
@@ -8,7 +8,8 @@ cluster_components:
     # Signals to zep-dev to apply the extra ArgoCD values overlay
     # that ensures we always schedule on a worker with the correct
     # mounts, and that the expected env variables exist, etc.
-    local_repo_integration: argo-cd
+    local_repo_integration:
+      type: argo-cd
     # Complete values to be passed to helm.
     values:
       applicationSet:

--- a/zep-dev/src/zep_dev/cluster.py
+++ b/zep-dev/src/zep_dev/cluster.py
@@ -11,10 +11,12 @@ import yaml
 from click import ClickException
 
 from zep_dev.k8s import KUBECONF_PATH, kube_guard, kubectl
+from zep_dev.k8s_secrets import resolve_registry_credential
 from zep_dev.models import (
     LOCAL_REPO_MOUNT_ROOT,
     ClusterComponents,
     LocalRepo,
+    OciRepository,
 )
 from zep_dev.shared import CommandResult, execute
 
@@ -290,14 +292,68 @@ def _install_helm_components(
                         encoding="utf-8",
                     )
                     install_args.extend(["-f", str(values_path)])
-                if desired.local_repo_integration == "argo-cd" and local_repos_overlay:
+                if desired.local_repo_integration is not None and local_repos_overlay:
+                    # TODO: If we add any more of these, don't just add more if conditionals, refactor
+                    # how this works. It will get spaghetti real fast otherwise.
+                    if desired.local_repo_integration.type != "argo-cd":
+                        raise ClickException(
+                            "Only argo-cd is supported for local_repo_integration.type"
+                        )
                     overlay_path = Path(tmpdir) / "local-repos-overlay.yaml"
                     overlay_path.write_text(
                         yaml.safe_dump(local_repos_overlay, default_flow_style=False),
                         encoding="utf-8",
                     )
                     install_args.extend(["-f", str(overlay_path)])
+
+                # Install the component.
                 helm(*install_args)
+
+        # Apply OCI repo secrets even when Argo is already installed so
+        # credentials stay current across repeated cluster create runs.
+        if desired.local_repo_integration is not None:
+            _apply_argo_oci_repository_secrets(
+                desired.namespace,
+                desired.local_repo_integration.oci_repositories,
+            )
+
+
+def _apply_argo_oci_repository_secrets(
+    namespace: str,
+    repositories: Sequence[OciRepository],
+) -> None:
+    """Apply Argo CD repository Secrets for Helm OCI registries.
+
+    Argo CD discovers private Helm OCI repos from Secrets labeled
+    argocd.argoproj.io/secret-type=repository; see
+    https://argo-cd.readthedocs.io/en/stable/operator-manual/secret-argocd-repo-credentials/
+    """
+    for repository in repositories:
+        username, password = resolve_registry_credential(repository.registry)
+        manifest = {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": repository.name,
+                "namespace": namespace,
+                "labels": {"argocd.argoproj.io/secret-type": "repository"},
+            },
+            "stringData": {
+                "type": "helm",
+                "name": repository.name,
+                "enableOCI": "true",
+                "url": repository.url,
+                "username": username,
+                "password": password,
+            },
+        }
+        LOG.info("Applying Argo OCI repository secret: %s", repository.url)
+        kubectl(
+            "apply",
+            "-f",
+            "-",
+            input=yaml.safe_dump(manifest, default_flow_style=False),
+        )
 
 
 def teardown_cluster() -> None:

--- a/zep-dev/src/zep_dev/k8s.py
+++ b/zep-dev/src/zep_dev/k8s.py
@@ -23,9 +23,13 @@ def kube_guard() -> Generator[None]:
         os.environ.pop("KUBECONFIG", None)
 
 
-def kubectl(*args: str, capture_stdout: bool = False) -> CommandResult:
+def kubectl(
+    *args: str,
+    capture_stdout: bool = False,
+    input: str | None = None,
+) -> CommandResult:
     with kube_guard():
-        return execute("kubectl", *args, capture_stdout=capture_stdout)
+        return execute("kubectl", *args, capture_stdout=capture_stdout, input=input)
 
 
 def resource_exists(

--- a/zep-dev/src/zep_dev/k8s_secrets.py
+++ b/zep-dev/src/zep_dev/k8s_secrets.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import logging
 from pathlib import Path
 
@@ -12,6 +14,26 @@ IMAGE_SECRET_PATHS = [
 IMAGE_SECRET_NAME = "github-registry"
 
 LOG = logging.getLogger(__name__)
+
+
+def resolve_registry_credential(registry: str) -> tuple[str, str]:
+    try:
+        for path in IMAGE_SECRET_PATHS:
+            if not path.is_file():
+                continue
+            entry = json.loads(path.read_text(encoding="utf-8"))["auths"].get(registry)
+            if entry is None:
+                continue
+            decoded = base64.b64decode(entry["auth"], validate=True).decode("utf-8")
+            username, password = decoded.split(":", 1)
+            if not username or not password:
+                raise ValueError("credential contains an empty username or password")
+            return username, password
+        raise LookupError("credential was not found in local container auth")
+    except Exception as error:
+        raise ClickException(
+            f"Failed to resolve local credential for {registry}: {type(error).__name__}"
+        ) from error
 
 
 def create_image_pull_secret(namespace: str) -> None:

--- a/zep-dev/src/zep_dev/models.py
+++ b/zep-dev/src/zep_dev/models.py
@@ -24,13 +24,30 @@ class LocalRepo:
         return f"{LOCAL_REPO_MOUNT_ROOT}/{self.basename}"
 
 
+class OciRepository(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    name: str = Field(min_length=1)
+    registry: str = Field(min_length=1)
+    repository: str = Field(min_length=1)
+
+    @property
+    def url(self) -> str:
+        return f"{self.registry}/{self.repository}"
+
+
+class LocalRepoIntegration(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["argo-cd"]
+    oci_repositories: list[OciRepository] = Field(default_factory=list)
+
+
 class ClusterComponent(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str
     chart: str
     version: str
     namespace: str
-    local_repo_integration: Literal["argo-cd"] | None = None
+    local_repo_integration: LocalRepoIntegration | None = None
     values: dict[str, Any] = Field(default_factory=dict)
 
 

--- a/zep-dev/tests/test_secrets.py
+++ b/zep-dev/tests/test_secrets.py
@@ -1,13 +1,51 @@
+import base64
+import json
 from pathlib import Path
 from unittest.mock import call
 
 import pytest
+from click import ClickException
 from click.testing import CliRunner
 
 from _fake_execute import FakeExecute
 from zep_dev import k8s, k8s_secrets
 from zep_dev.cli import cli
 from zep_dev.k8s_secrets import IMAGE_SECRET_NAME
+
+
+def test_resolve_registry_credential_selects_registry_and_has_secret_free_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth_path = tmp_path / "auth.json"
+    requested_auth = base64.b64encode(b"octocat:ghp_requested").decode()
+    other_auth = base64.b64encode(b"other:ghp_other").decode()
+    auth_path.write_text(
+        json.dumps(
+            {
+                "auths": {
+                    "example.com": {"auth": other_auth},
+                    "ghcr.io": {"auth": requested_auth},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(k8s_secrets, "IMAGE_SECRET_PATHS", [auth_path])
+
+    assert k8s_secrets.resolve_registry_credential("ghcr.io") == (
+        "octocat",
+        "ghp_requested",
+    )
+
+    with pytest.raises(ClickException) as exc_info:
+        k8s_secrets.resolve_registry_credential("missing.example.com")
+    error = str(exc_info.value)
+    assert "missing.example.com" in error
+    assert requested_auth not in error
+    assert "ghp_requested" not in error
+    assert other_auth not in error
+    assert "ghp_other" not in error
 
 
 @pytest.fixture

--- a/zep-dev/tests/test_zep_dev.py
+++ b/zep-dev/tests/test_zep_dev.py
@@ -15,7 +15,12 @@ from zep_dev.k8s import (
     KUBECONF_PATH,
     kube_guard,
 )
-from zep_dev.models import ClusterComponent, ClusterComponents, LocalRepo
+from zep_dev.models import (
+    ClusterComponent,
+    ClusterComponents,
+    LocalRepo,
+    LocalRepoIntegration,
+)
 
 EXAMPLES = Path(__file__).resolve().parent.parent / "examples"
 
@@ -33,7 +38,7 @@ def test_examples_components_yaml_parses() -> None:
     assert argo_cd.chart == "argo/argo-cd"
     assert argo_cd.version == "9.5.0"
     assert argo_cd.namespace == "argo-cd"
-    assert argo_cd.local_repo_integration == "argo-cd"
+    assert argo_cd.local_repo_integration == LocalRepoIntegration(type="argo-cd")
     assert argo_cd.values["server"]["service"]["type"] == "NodePort"
     assert argo_cd.values["configs"]["cm"]["admin.enabled"] is True
     assert argo_cd.values["dex"]["enabled"] is False
@@ -91,8 +96,10 @@ def test_add_helm_repos_skips_all_helm_when_no_repos_configured(
 def test_install_helm_components_applies_local_repo_integration_only_to_selected_component(
     fake_execute: Callable[[ModuleType], FakeExecute],
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     installed_values: dict[str, list[object]] = {}
+    reconciled_components: list[str] = []
 
     def capture_values(args: tuple[str, ...], kwargs: dict[str, object]) -> None:
         _, _, release, *_ = args
@@ -105,6 +112,11 @@ def test_install_helm_components_applies_local_repo_integration_only_to_selected
     fake.on("helm", "list", stdout="")
     fake.on("helm", "install", "argo", hook=capture_values)
     fake.on("helm", "install", "other", hook=capture_values)
+    monkeypatch.setattr(
+        cluster,
+        "_apply_argo_oci_repository_secrets",
+        lambda namespace, _repositories: reconciled_components.append(namespace),
+    )
     components = ClusterComponents(
         helm_repos={},
         cluster_components=[
@@ -113,7 +125,7 @@ def test_install_helm_components_applies_local_repo_integration_only_to_selected
                 chart="example/argo",
                 version="1.0.0",
                 namespace="argo",
-                local_repo_integration="argo-cd",
+                local_repo_integration=LocalRepoIntegration(type="argo-cd"),
                 values={"base": "argo"},
             ),
             ClusterComponent(
@@ -132,6 +144,7 @@ def test_install_helm_components_applies_local_repo_integration_only_to_selected
     )
 
     assert installed_values["other"] == [{"base": "other"}]
+    assert reconciled_components == ["argo"]
     base_values, overlay = installed_values["argo"]
     assert base_values == {"base": "argo"}
     assert overlay == {


### PR DESCRIPTION
We need to be able to pull charts from our private repos, and to do this
we need our OCI creds in the cluster. Support automagically injecting
them from the local auth path where they live naturally. This prevents
needing to configure a local values file with creds in them.

Refactor a little the object model to support this.

Signed-off-by: William Coe <william.coe@zepben.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>