### PR TITLE
Validate sha on tool download

### DIFF
--- a/zep-dev/src/zep_dev/commands/tools/commands.py
+++ b/zep-dev/src/zep_dev/commands/tools/commands.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import platform
 import shutil
@@ -32,7 +33,14 @@ DOWNLOAD_TIMEOUT_SECONDS = 60
 DOWNLOAD_ATTEMPTS = 5
 
 
-def download_url(url: str, dest: Path, *, label: str | None = None) -> None:
+def download_url(
+    url: str,
+    dest: Path,
+    *,
+    expected_sha256: str,
+    label: str | None = None,
+) -> None:
+    hasher = hashlib.sha256()
     with requests.get(url, stream=True, timeout=DOWNLOAD_TIMEOUT_SECONDS) as response:
         response.raise_for_status()
         length = int(response.headers.get("Content-Length", 0)) or None
@@ -48,10 +56,24 @@ def download_url(url: str, dest: Path, *, label: str | None = None) -> None:
                 if not chunk:
                     continue
                 out.write(chunk)
+                hasher.update(chunk)
                 bar.update(len(chunk))
+    actual = hasher.hexdigest()
+    if actual != expected_sha256:
+        dest.unlink(missing_ok=True)
+        raise click.ClickException(
+            f"SHA256 mismatch for {label or dest.name}: "
+            f"expected {expected_sha256}, got {actual}"
+        )
 
 
-def download(url: str, dest: Path, *, label: str | None = None) -> None:
+def download(
+    url: str,
+    dest: Path,
+    *,
+    expected_sha256: str,
+    label: str | None = None,
+) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     for attempt in Retrying(
         stop=stop_after_attempt(DOWNLOAD_ATTEMPTS),
@@ -62,7 +84,7 @@ def download(url: str, dest: Path, *, label: str | None = None) -> None:
     ):
         with attempt:
             try:
-                download_url(url, dest, label=label)
+                download_url(url, dest, expected_sha256=expected_sha256, label=label)
             except Exception:
                 dest.unlink(missing_ok=True)
                 raise
@@ -81,13 +103,13 @@ def install_binary_tool(tool: RequiredTool, tools_dir: Path) -> Path:
     url = tool.url.format(version=tool.version)
     dest = tools_dir / tool.name
     if tool.archive_member is None:
-        download(url, dest, label=tool.name)
+        download(url, dest, expected_sha256=tool.sha256, label=tool.name)
     else:
         member = tool.archive_member.format(version=tool.version)
         with TemporaryDirectory() as tmp:
             work = Path(tmp)
             archive = work / "archive.tar.gz"
-            download(url, archive, label=tool.name)
+            download(url, archive, expected_sha256=tool.sha256, label=tool.name)
             extract_archive_member(archive, member, work)
             shutil.copy2(work / member, dest)
 

--- a/zep-dev/src/zep_dev/models.py
+++ b/zep-dev/src/zep_dev/models.py
@@ -56,10 +56,11 @@ class RequiredTool(BaseModel):
     name: str
     version: str
     url: str
+    sha256: str = Field(min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$")
     archive_member: str | None = None
 
     def to_hash(self) -> str:
-        return f"{self.name}-{self.version}-{self.url}"
+        return f"{self.name}-{self.version}-{self.url}-{self.sha256}"
 
     def exists(self, hash_dir: Path) -> bool:
         with suppress(OSError):

--- a/zep-dev/src/zep_dev/static.py
+++ b/zep-dev/src/zep_dev/static.py
@@ -7,6 +7,7 @@ TOOLS: list[RequiredTool] = [
         name="helm",
         version="v4.2.2",
         url="https://get.helm.sh/helm-{version}-linux-amd64.tar.gz",
+        sha256="9adafecab4d406853bba163a70e9f104f47dbbf65ce24b7653bae7e36150bcb6",
         archive_member="linux-amd64/helm",
     ),
     RequiredTool(
@@ -16,6 +17,7 @@ TOOLS: list[RequiredTool] = [
             "https://github.com/helm/chart-testing/releases/download/"
             "v{version}/chart-testing_{version}_linux_amd64.tar.gz"
         ),
+        sha256="d16f0583616885423826241164ce1f6589c6fe5332fa74f374ebd2bd3cb3fe1f",
         archive_member="ct",
     ),
     RequiredTool(
@@ -25,17 +27,20 @@ TOOLS: list[RequiredTool] = [
             "https://github.com/yannh/kubeconform/releases/download/"
             "{version}/kubeconform-linux-amd64.tar.gz"
         ),
+        sha256="9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883",
         archive_member="kubeconform",
     ),
     RequiredTool(
         name="kind",
         version="v0.32.0",
         url="https://kind.sigs.k8s.io/dl/{version}/kind-linux-amd64",
+        sha256="50030de23cf40a18505f20426f6a8506bedf13c6e509244bd1fa9463721b0f54",
     ),
     RequiredTool(
         name="kubectl",
         version="v1.36.2",
         url="https://dl.k8s.io/release/{version}/bin/linux/amd64/kubectl",
+        sha256="1e9045ec32bea85da43de85f0065358529ea7c7a152eca78154fba5b58c27d82",
     ),
     RequiredTool(
         name="shellcheck",
@@ -44,6 +49,7 @@ TOOLS: list[RequiredTool] = [
             "https://github.com/koalaman/shellcheck/releases/download/"
             "{version}/shellcheck-{version}.linux.x86_64.tar.gz"
         ),
+        sha256="b7af85e41cc99489dcc21d66c6d5f3685138f06d34651e6d34b42ec6d54fe6f6",
         archive_member="shellcheck-{version}/shellcheck",
     ),
     RequiredTool(
@@ -53,6 +59,7 @@ TOOLS: list[RequiredTool] = [
             "https://github.com/kyverno/chainsaw/releases/download/"
             "v{version}/chainsaw_linux_amd64.tar.gz"
         ),
+        sha256="295d226c89f126c0a97775d364be149f47a810c8a3f9829ee410583d0c1abe3c",
         archive_member="chainsaw",
     ),
     RequiredTool(
@@ -62,6 +69,7 @@ TOOLS: list[RequiredTool] = [
             "https://github.com/argoproj/argo-cd/releases/download/"
             "{version}/argocd-linux-amd64"
         ),
+        sha256="36c243afeb46bbaedec3c9b6823c043a741a36b1b8215147676bb8f18f21ef73",
     ),
 ]
 TOOLS_BY_NAME = {tool.name: tool for tool in TOOLS}

--- a/zep-dev/tests/test_models.py
+++ b/zep-dev/tests/test_models.py
@@ -11,6 +11,7 @@ def tool() -> RequiredTool:
         name="ct",
         version="1.0",
         url="http://example/{version}",
+        sha256="0" * 64,
         archive_member="ct",
     )
 

--- a/zep-dev/tests/test_tools_install.py
+++ b/zep-dev/tests/test_tools_install.py
@@ -37,6 +37,7 @@ def test_install_binary_tool_from_archive(
         name="test-tool",
         version="3.14.0",
         url="http://unused/{version}",
+        sha256="0" * 64,
         archive_member="ct",
     )
     dest = install_binary_tool(tool, tools_dir)
@@ -51,11 +52,17 @@ def test_download_cleans_up_after_exhausted_retries(
 ) -> None:
     dest = tmp_path / "tool"
 
-    def write_then_fail(url: str, dest: Path, *, label: str | None = None) -> None:
+    def write_then_fail(
+        url: str,
+        dest: Path,
+        *,
+        expected_sha256: str,
+        label: str | None = None,
+    ) -> None:
         dest.write_bytes(b"partial")
         raise RequestException("fail")
 
     monkeypatch.setattr(install_module, "download_url", write_then_fail)
     with pytest.raises(RequestException):
-        download("http://example/tool", dest)
+        download("http://example/tool", dest, expected_sha256="0" * 64)
     assert not dest.exists()


### PR DESCRIPTION
To protect against corruption and close a potential security issue,
ensure we always check the expected sha of our tools after download and
fail if they don't match.

Signed-off-by: William Coe <william.coe@zepben.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>