### PR TITLE
[DEV-9810] Execute kubeconform during lint stage

### DIFF
--- a/zep-dev/src/zep_dev/commands/chart/lint.py
+++ b/zep-dev/src/zep_dev/commands/chart/lint.py
@@ -6,8 +6,14 @@ import click
 from click import ClickException
 
 from zep_dev.models import ChartMetadata, ChartTestingConfig
-from zep_dev.shared import execute, resolve_chart
+from zep_dev.shared import ResolvedChart, execute, resolve_chart
 from zep_dev.static import CT_YAML
+
+KUBERNETES_VERSION = "1.35.0"
+DATREE_CRD_SCHEMA_LOCATION = (
+    "https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/"
+    "{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json"
+)
 
 
 @click.command("lint")
@@ -42,18 +48,81 @@ def lint(helm_dir: Path, chart: Path) -> None:
     chart_metadata = ChartMetadata.from_chart_dir(resolved_chart.absolute_path)
     validate_dependencies_present(chart_metadata, ct_config, ct_path)
     with chdir(helm_dir):
-        try:
-            execute(
-                "ct",
-                "lint",
-                "--config",
-                str(CT_YAML),
-                "--charts",
-                str(resolved_chart.path_relative_to_helm_dir),
-                "--check-version-increment=true",
+        run_chart_testing_lint(resolved_chart)
+        validate_chart_manifests(resolved_chart, chart_metadata)
+
+
+def run_chart_testing_lint(resolved_chart: ResolvedChart) -> None:
+    try:
+        execute(
+            "ct",
+            "lint",
+            "--config",
+            str(CT_YAML),
+            "--charts",
+            str(resolved_chart.path_relative_to_helm_dir),
+            "--check-version-increment=true",
+        )
+    except CalledProcessError as e:
+        raise ClickException(f"lint failed with rc={e.returncode}") from e
+
+
+def validate_chart_manifests(
+    resolved_chart: ResolvedChart, chart_metadata: ChartMetadata
+) -> None:
+    if chart_metadata.type == "library":
+        click.echo(f"Skipping kubeconform for library chart: {chart_metadata.name}")
+        return
+    helm_args = [
+        "helm",
+        "template",
+        chart_metadata.name,
+        str(resolved_chart.path_relative_to_helm_dir),
+        "--kube-version",
+        KUBERNETES_VERSION,
+        "--include-crds",
+    ]
+    values_files = [
+        path.relative_to(resolved_chart.absolute_path)
+        for path in sorted(resolved_chart.absolute_path.glob("ci/*-values.yaml"))
+    ]
+    if not values_files:
+        execute_kubeconform(helm_args, "chart defaults")
+    else:
+        for values_file in values_files:
+            values_path = resolved_chart.path_relative_to_helm_dir / values_file
+            execute_kubeconform(
+                [*helm_args, "--values", str(values_path)], str(values_path)
             )
-        except CalledProcessError as e:
-            raise ClickException(f"lint failed with rc={e.returncode}") from e
+
+
+def execute_kubeconform(helm_args: list[str], variant: str) -> None:
+    click.echo(f"Validating Kubernetes schemas for {variant}")
+    try:
+        rendered = execute(*helm_args, capture_stdout=True)
+    except CalledProcessError as e:
+        raise ClickException(
+            f"helm template failed for {variant} with rc={e.returncode}"
+        ) from e
+
+    try:
+        execute(
+            "kubeconform",
+            "-kubernetes-version",
+            KUBERNETES_VERSION,
+            "-strict",
+            "-ignore-missing-schemas",
+            "-schema-location",
+            "default",
+            "-schema-location",
+            DATREE_CRD_SCHEMA_LOCATION,
+            "-summary",
+            input=rendered.stdout,
+        )
+    except CalledProcessError as e:
+        raise ClickException(
+            f"kubeconform failed for {variant} with rc={e.returncode}"
+        ) from e
 
 
 def validate_dependencies_present(

--- a/zep-dev/tests/test_chart_lint.py
+++ b/zep-dev/tests/test_chart_lint.py
@@ -73,7 +73,12 @@ def test_lint_dependency_repository_present_runs_ct(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     write_chart_testing_config(chart_testing_config)
-    fake = fake_execute(lint_module).on("ct", "lint")
+    fake = (
+        fake_execute(lint_module)
+        .on("ct", "lint")
+        .on("helm", "template")
+        .on("kubeconform")
+    )
 
     monkeypatch.chdir(helm_dir)
     result = CliRunner().invoke(
@@ -93,6 +98,36 @@ def test_lint_dependency_repository_present_runs_ct(
             "--check-version-increment=true",
         )
     ]
+
+
+def test_lint_library_chart_skips_kubeconform(
+    helm_dir: Path,
+    chart_testing_config: ChartTestingConfig,
+    write_chart_testing_config: Callable[[ChartTestingConfig], None],
+    fake_execute: Callable[[ModuleType], FakeExecute],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    write_chart_testing_config(chart_testing_config)
+    write_chart(
+        helm_dir / "charts" / "common",
+        {
+            "apiVersion": "v2",
+            "name": "common",
+            "version": "0.2.0",
+            "type": "library",
+        },
+    )
+    fake = fake_execute(lint_module).on("ct", "lint")
+
+    monkeypatch.chdir(helm_dir)
+    result = CliRunner().invoke(
+        cli,
+        ["chart", "lint", "--helm-dir", ".", "--chart", "charts/common"],
+    )
+
+    assert result.exit_code == 0
+    assert fake.calls_for("helm", "template") == []
+    assert fake.calls_for("kubeconform") == []
 
 
 def test_lint_dependency_repository_missing_from_ct_config_fails(


### PR DESCRIPTION
This was an oversight, should added it originally but forgot. Execute kubeconform as an additional safety check as per the RFC.
