### PR TITLE
Resolve Helm config automagically

### DIFF
--- a/zep-dev/src/zep_dev/cli.py
+++ b/zep-dev/src/zep_dev/cli.py
@@ -7,7 +7,9 @@ from zep_dev.groups.chart import chart
 from zep_dev.groups.cluster import cluster
 from zep_dev.groups.secrets import secrets
 from zep_dev.groups.tools import tools
-from zep_dev.shared import get_bin_dir
+from zep_dev.shared import get_bin_dir, resolve_registry_config
+
+LOG = logging.getLogger(__name__)
 
 
 @click.group(help="Manage a local kind cluster for chart testing")
@@ -15,8 +17,9 @@ from zep_dev.shared import get_bin_dir
     "-v", "--verbose", count=True, help="Increase log verbosity (-v=INFO, -vv=DEBUG)"
 )
 def cli(verbose: int) -> None:
-    add_bin_dir_to_path()
     configure_logging(verbose)
+    add_bin_dir_to_path()
+    configure_helm_registry()
 
 
 def add_bin_dir_to_path() -> None:
@@ -26,6 +29,19 @@ def add_bin_dir_to_path() -> None:
     bin_dir = str(get_bin_dir().resolve())
     path = os.environ.get("PATH", "")
     os.environ["PATH"] = f"{bin_dir}{os.pathsep}{path}"
+
+
+def configure_helm_registry() -> None:
+    if "HELM_REGISTRY_CONFIG" in os.environ:
+        return
+    # Helm uses it's own standard location for the registry by default. The structure is
+    # exactly the same as the docker/podman registry config, so just locate and use it directly
+    # instead of requiring people to duplicate the file. It is implemented as an env var so that
+    # child processes (like ct) can inherit the same config.
+    registry_config = resolve_registry_config()
+    if registry_config is not None:
+        LOG.debug("Setting registry config: HELM_REGISTRY_CONFIG=%s", registry_config)
+        os.environ["HELM_REGISTRY_CONFIG"] = str(registry_config)
 
 
 def configure_logging(verbose: int) -> None:

--- a/zep-dev/src/zep_dev/commands/chart/test.py
+++ b/zep-dev/src/zep_dev/commands/chart/test.py
@@ -11,7 +11,11 @@ from pydantic import ValidationError
 from zep_dev.k8s import kubectl, resource_exists
 from zep_dev.k8s_secrets import create_image_pull_secret
 from zep_dev.models import ChartMetadata, CiSecrets
-from zep_dev.shared import ResolvedChart, execute, resolve_chart
+from zep_dev.shared import (
+    ResolvedChart,
+    execute,
+    resolve_chart,
+)
 from zep_dev.static import CI_SECRETS_YAML, CT_YAML
 
 LOG = logging.getLogger(__name__)

--- a/zep-dev/src/zep_dev/shared.py
+++ b/zep-dev/src/zep_dev/shared.py
@@ -11,6 +11,12 @@ from zep_dev.static import TOOLS_BY_NAME
 
 LOG = logging.getLogger(__name__)
 
+REGISTRY_CONFIG_PATHS = (
+    Path.home() / ".config" / "helm" / "registry" / "config.json",
+    Path.home() / ".config" / "containers" / "auth.json",
+    Path.home() / ".docker" / "config.json",
+)
+
 
 @dataclass(frozen=True)
 class CommandResult:
@@ -23,6 +29,10 @@ class CommandResult:
 class ResolvedChart:
     absolute_path: Path
     path_relative_to_helm_dir: Path
+
+
+def resolve_registry_config() -> Path | None:
+    return next((path for path in REGISTRY_CONFIG_PATHS if path.is_file()), None)
 
 
 def resolve_chart(helm_dir: Path, chart: Path) -> ResolvedChart:

--- a/zep-dev/tests/test_cli.py
+++ b/zep-dev/tests/test_cli.py
@@ -5,15 +5,20 @@ from unittest.mock import MagicMock, patch
 from click.testing import CliRunner
 
 import zep_dev.cli as cli_module
-from zep_dev.cli import add_bin_dir_to_path, cli
+from zep_dev.cli import add_bin_dir_to_path, cli, configure_helm_registry
 
 
 @patch.object(cli_module, "add_bin_dir_to_path")
-def test_cli_calls_add_bin_dir_to_path(mock_add_bin_dir_to_path: MagicMock) -> None:
+@patch.object(cli_module, "configure_helm_registry")
+def test_cli_configures_process_environment(
+    mock_configure_helm_registry: MagicMock,
+    mock_add_bin_dir_to_path: MagicMock,
+) -> None:
     result = CliRunner().invoke(cli, ["tools", "--help"])
 
     assert result.exit_code == 0
     mock_add_bin_dir_to_path.assert_called_once()
+    mock_configure_helm_registry.assert_called_once()
 
 
 @patch.object(cli_module, "get_bin_dir")
@@ -28,3 +33,30 @@ def test_add_bin_dir_to_path_prepends(
     with patch.dict(os.environ, {"PATH": "/usr/bin:/bin"}, clear=False):
         add_bin_dir_to_path()
         assert os.environ["PATH"] == f"{bin_dir.resolve()}{os.pathsep}/usr/bin:/bin"
+
+
+@patch.object(cli_module, "resolve_registry_config")
+def test_configure_helm_registry_sets_discovered_config(
+    mock_resolve_registry_config: MagicMock,
+    tmp_path: Path,
+) -> None:
+    registry_config = tmp_path / "config.json"
+    mock_resolve_registry_config.return_value = registry_config
+
+    with patch.dict(os.environ, {}, clear=True):
+        configure_helm_registry()
+        assert os.environ["HELM_REGISTRY_CONFIG"] == str(registry_config)
+
+
+@patch.object(cli_module, "resolve_registry_config")
+def test_configure_helm_registry_preserves_explicit_config(
+    mock_resolve_registry_config: MagicMock,
+) -> None:
+    with patch.dict(
+        os.environ,
+        {"HELM_REGISTRY_CONFIG": "/explicit/config.json"},
+        clear=True,
+    ):
+        configure_helm_registry()
+
+    mock_resolve_registry_config.assert_not_called()

--- a/zep-dev/tests/test_shared.py
+++ b/zep-dev/tests/test_shared.py
@@ -3,7 +3,11 @@ from pathlib import Path
 import pytest
 
 import zep_dev.shared as shared
-from zep_dev.shared import ResolvedChart, resolve, resolve_chart
+from zep_dev.shared import (
+    ResolvedChart,
+    resolve,
+    resolve_chart,
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
Helm by default looks in ~/.config/helm/registry/config.json for the registry configuration. It is the exact same structure as Podman's ~/.config/containers/auth.json and Docker's ~/.docker/config.json. Rather than require that developers duplicate the config in multiple places, just follow our existing resolution path to find the config and inject into an env variable for Helm to pick it up. We use a global env variable so that any processes we spawn will inherit it. This ensures that tools such as Chart Testing will work correctly and be able to resolve charts that live in private repos using these creds.
