### PR TITLE
[DEV-10072] Enforce standard chart/lint structure

### DIFF
--- a/zep-dev/README.md
+++ b/zep-dev/README.md
@@ -19,6 +19,9 @@ make check-zep-dev test-zep-dev
 
 To execute the linters and tests. 
 
+`zep-dev chart lint` and `zep-dev chart test` enforce the chart metadata schema
+and YAML lint policy bundled with `zep-dev`.
+
 To create a local kind cluster, you can run:
 ```shell
 make setup-k8s

--- a/zep-dev/src/zep_dev/commands/chart/lint.py
+++ b/zep-dev/src/zep_dev/commands/chart/lint.py
@@ -5,6 +5,7 @@ from subprocess import CalledProcessError
 import click
 from click import ClickException
 
+from zep_dev.commands.chart.utils import execute_ct_lint
 from zep_dev.models import ChartMetadata, ChartTestingConfig
 from zep_dev.shared import ResolvedChart, execute, resolve_chart
 from zep_dev.static import CT_YAML
@@ -54,8 +55,7 @@ def lint(helm_dir: Path, chart: Path) -> None:
 
 def run_chart_testing_lint(resolved_chart: ResolvedChart) -> None:
     try:
-        execute(
-            "ct",
+        execute_ct_lint(
             "lint",
             "--config",
             str(CT_YAML),

--- a/zep-dev/src/zep_dev/commands/chart/test.py
+++ b/zep-dev/src/zep_dev/commands/chart/test.py
@@ -8,12 +8,12 @@ import yaml
 from click import ClickException
 from pydantic import ValidationError
 
+from zep_dev.commands.chart.utils import execute_ct_lint
 from zep_dev.k8s import kubectl, resource_exists
 from zep_dev.k8s_secrets import create_image_pull_secret
 from zep_dev.models import ChartMetadata, CiSecrets
 from zep_dev.shared import (
     ResolvedChart,
-    execute,
     resolve_chart,
 )
 from zep_dev.static import CI_SECRETS_YAML, CT_YAML
@@ -133,8 +133,7 @@ def execute_lint_and_install(
     ct_yaml_path: Path, chart_path_relative_to_helm_dir: Path
 ) -> None:
     try:
-        execute(
-            "ct",
+        execute_ct_lint(
             "lint-and-install",
             "--config",
             str(ct_yaml_path),

--- a/zep-dev/src/zep_dev/commands/chart/utils.py
+++ b/zep-dev/src/zep_dev/commands/chart/utils.py
@@ -1,0 +1,23 @@
+from importlib.resources import as_file, files
+from typing import Literal
+
+from zep_dev.shared import CommandResult, execute
+
+
+def execute_ct_lint(
+    command: Literal["lint", "lint-and-install"], *args: str
+) -> CommandResult:
+    resources = files("zep_dev.resources")
+    with (
+        as_file(resources.joinpath("chart_schema.yaml")) as chart_schema,
+        as_file(resources.joinpath("lintconf.yaml")) as lint_config,
+    ):
+        return execute(
+            "ct",
+            command,
+            *args,
+            "--chart-yaml-schema",
+            str(chart_schema),
+            "--lint-conf",
+            str(lint_config),
+        )

--- a/zep-dev/src/zep_dev/resources/chart_schema.yaml
+++ b/zep-dev/src/zep_dev/resources/chart_schema.yaml
@@ -1,0 +1,40 @@
+name: str()
+home: str()
+version: str()
+apiVersion: str()
+appVersion: any(str(), num(), required=False)
+description: str()
+keywords: list(str(), required=False)
+sources: list(str(), min=1)
+maintainers: list(include('maintainer'), required=False)
+dependencies: list(include('dependency'), required=False)
+icon: str(required=False)
+engine: str(required=False)
+condition: str(required=False)
+deprecated: bool(required=False)
+kubeVersion: str(required=False)
+annotations: include('ghcr_annotations', strict=False)
+type: str(required=False)
+---
+ghcr_annotations:
+  org.opencontainers.image.source: str()
+  org.opencontainers.image.description: str()
+---
+maintainer:
+  name: str()
+  email: str(required=False)
+  url: str(required=False)
+---
+dependency:
+  name: str()
+  version: str()
+  repository: str(required=False)
+  condition: str(required=False)
+  tags: list(str(), required=False)
+  enabled: bool(required=False)
+  import-values: any(list(str()), list(include('import-value')), required=False)
+  alias: str(required=False)
+---
+import-value:
+  child: str()
+  parent: str()

--- a/zep-dev/src/zep_dev/resources/lintconf.yaml
+++ b/zep-dev/src/zep_dev/resources/lintconf.yaml
@@ -1,0 +1,42 @@
+---
+rules:
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  brackets:
+    min-spaces-inside: 0
+    max-spaces-inside: 0
+    min-spaces-inside-empty: -1
+    max-spaces-inside-empty: -1
+  colons:
+    max-spaces-before: 0
+    max-spaces-after: 1
+  commas:
+    max-spaces-before: 0
+    min-spaces-after: 1
+    max-spaces-after: 1
+  comments:
+    require-starting-space: true
+    min-spaces-from-content: 2
+  document-end: disable
+  document-start: disable
+  empty-lines:
+    max: 2
+    max-start: 0
+    max-end: 0
+  hyphens:
+    max-spaces-after: 1
+  indentation:
+    spaces: consistent
+    indent-sequences: whatever
+    check-multi-line-strings: false
+  key-duplicates: enable
+  line-length: disable
+  new-line-at-end-of-file: enable
+  new-lines:
+    type: unix
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/zep-dev/tests/test_chart_lint.py
+++ b/zep-dev/tests/test_chart_lint.py
@@ -11,6 +11,7 @@ from _charts import write_chart
 from _fake_execute import FakeExecute
 from zep_dev.cli import cli
 from zep_dev.commands.chart import lint as lint_module
+from zep_dev.commands.chart import utils as ct_module
 from zep_dev.models import ChartTestingConfig
 
 
@@ -79,6 +80,7 @@ def test_lint_dependency_repository_present_runs_ct(
         .on("helm", "template")
         .on("kubeconform")
     )
+    monkeypatch.setattr(ct_module, "execute", fake)
 
     monkeypatch.chdir(helm_dir)
     result = CliRunner().invoke(
@@ -87,17 +89,20 @@ def test_lint_dependency_repository_present_runs_ct(
     )
 
     assert result.exit_code == 0
-    assert fake.calls_for("ct") == [
-        call(
-            "ct",
-            "lint",
-            "--config",
-            "ct.yaml",
-            "--charts",
-            "charts/example-chart",
-            "--check-version-increment=true",
-        )
-    ]
+    [ct_call] = fake.calls_for("ct")
+    assert ct_call == call(
+        "ct",
+        "lint",
+        "--config",
+        "ct.yaml",
+        "--charts",
+        "charts/example-chart",
+        "--check-version-increment=true",
+        "--chart-yaml-schema",
+        str(ct_module.files("zep_dev.resources").joinpath("chart_schema.yaml")),
+        "--lint-conf",
+        str(ct_module.files("zep_dev.resources").joinpath("lintconf.yaml")),
+    )
 
 
 def test_lint_library_chart_skips_kubeconform(
@@ -118,6 +123,7 @@ def test_lint_library_chart_skips_kubeconform(
         },
     )
     fake = fake_execute(lint_module).on("ct", "lint")
+    monkeypatch.setattr(ct_module, "execute", fake)
 
     monkeypatch.chdir(helm_dir)
     result = CliRunner().invoke(
@@ -140,7 +146,8 @@ def test_lint_dependency_repository_missing_from_ct_config_fails(
 ) -> None:
     chart_testing_config.chart_repos = ["other-repo=https://other.example.com/charts"]
     write_chart_testing_config(chart_testing_config)
-    fake = fake_execute(lint_module).on("ct", "lint")
+    fake = fake_execute(lint_module)
+    monkeypatch.setattr(ct_module, "execute", fake)
 
     monkeypatch.chdir(helm_dir)
     result = CliRunner().invoke(

--- a/zep-dev/tests/test_chart_test.py
+++ b/zep-dev/tests/test_chart_test.py
@@ -12,6 +12,7 @@ from _fake_execute import FakeExecute
 from zep_dev import k8s, k8s_secrets
 from zep_dev.cli import cli
 from zep_dev.commands.chart import test as test_module
+from zep_dev.commands.chart import utils as ct_module
 from zep_dev.k8s_secrets import IMAGE_SECRET_NAME
 
 
@@ -45,7 +46,7 @@ def _install_chart_fakes(
     monkeypatch.setattr(k8s_secrets, "kubectl", kubectl_fake)
     return ChartTestFakes(
         kubectl=kubectl_fake,
-        execute=fake_execute(test_module),
+        execute=fake_execute(ct_module),
     )
 
 
@@ -109,6 +110,10 @@ def test_application_chart_runs_lint_and_install(
         "--charts",
         "charts/myapp",
         "--check-version-increment=true",
+        "--chart-yaml-schema",
+        str(ct_module.files("zep_dev.resources").joinpath("chart_schema.yaml")),
+        "--lint-conf",
+        str(ct_module.files("zep_dev.resources").joinpath("lintconf.yaml")),
     )
 
 
@@ -175,6 +180,10 @@ def test_discovery_mode_processes_all_charts_and_skips_libraries(
             "--charts",
             "charts/app-a",
             "--check-version-increment=true",
+            "--chart-yaml-schema",
+            str(ct_module.files("zep_dev.resources").joinpath("chart_schema.yaml")),
+            "--lint-conf",
+            str(ct_module.files("zep_dev.resources").joinpath("lintconf.yaml")),
         ),
         call(
             "ct",
@@ -184,5 +193,9 @@ def test_discovery_mode_processes_all_charts_and_skips_libraries(
             "--charts",
             "charts/app-b",
             "--check-version-increment=true",
+            "--chart-yaml-schema",
+            str(ct_module.files("zep_dev.resources").joinpath("chart_schema.yaml")),
+            "--lint-conf",
+            str(ct_module.files("zep_dev.resources").joinpath("lintconf.yaml")),
         ),
     ]


### PR DESCRIPTION
Instead of putting chart_schema.yaml and lint.conf in each Application repository, centralize this config and apply it always. This allows us to enforce a schema and standard lint on all repos. This fits with the RFC goal of prescriptive standards.

The config bundled here is the same as what has been used in eg evolve-web-app, with the addition of a few annotations that Github uses for displaying packages:

```
ghcr_annotations:
  org.opencontainers.image.source: str()
  org.opencontainers.image.description: str()
```

Enforcing these was the motivation for this change.

Existing config in repos will be ignored by the tool now, and I will remove from them in follow up PRs.
