### PR TITLE
[DEV-10076] Add command for generating RFC compliant version

### DIFF
--- a/zep-dev/src/zep_dev/commands/chart/version.py
+++ b/zep-dev/src/zep_dev/commands/chart/version.py
@@ -1,0 +1,76 @@
+import re
+from dataclasses import dataclass
+from subprocess import CalledProcessError
+
+import click
+from click import ClickException
+
+from zep_dev.shared import execute
+
+GIT_DESCRIBE_PATTERN = re.compile(
+    r"^v(?P<base>\d+\.\d+\.\d+)-(?P<height>\d+)-g(?P<sha>[0-9a-f]+)$"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class GitDescribe:
+    base: str
+    height: int
+    sha: str
+
+
+def parse_git_describe(output: str) -> GitDescribe:
+    match = GIT_DESCRIBE_PATTERN.fullmatch(output.strip())
+    if match is None:
+        raise ValueError(f"unexpected git describe output: {output.strip()!r}")
+
+    groups = match.groupdict()
+    return GitDescribe(
+        base=groups["base"],
+        height=int(groups["height"]),
+        sha=groups["sha"],
+    )
+
+
+def to_chart_version(description: GitDescribe) -> str:
+    if description.height == 0:
+        return description.base
+    return f"{description.base}-{description.height}+{description.sha}"
+
+
+def git_describe() -> str:
+    return execute(
+        "git",
+        "describe",
+        # Consider lightweight and annotated tags, not only annotated.
+        "--tags",
+        # Always emit <tag>-<height>-g<sha>, even when HEAD is exactly on a tag
+        "--long",
+        # Include v-prefixed release tags, e.g. v1.37.0.
+        "--match",
+        "v[0-9]*.[0-9]*.[0-9]*",
+        # Drop hyphen prereleases, e.g. v1.6.3-next1, v0.2.9-beta.1.
+        "--exclude",
+        "*-*",
+        # Drop letter-suffixed builds that still match the three-part glob,
+        # e.g. v2.15.0b4. Digit-then-letter avoids excluding the leading "v"
+        # on normal tags like v1.37.0.
+        "--exclude",
+        "*[0-9][a-zA-Z]*",
+        # Prefer 7-char SHAs; Git may lengthen for uniqueness.
+        "--abbrev=7",
+        skip_resolve=True,
+        capture_stdout=True,
+    ).stdout
+
+
+@click.command("version")
+def version() -> None:
+    try:
+        describe_output = parse_git_describe(git_describe())
+    except CalledProcessError as e:
+        raise ClickException(f"git describe failed with rc={e.returncode}") from e
+    except ValueError as e:
+        raise ClickException(str(e)) from e
+
+    click.echo(to_chart_version(describe_output))

--- a/zep-dev/src/zep_dev/groups/chart.py
+++ b/zep-dev/src/zep_dev/groups/chart.py
@@ -5,6 +5,7 @@ from zep_dev.commands.chart.list_changed import list_changed
 from zep_dev.commands.chart.metadata import metadata
 from zep_dev.commands.chart.push import push
 from zep_dev.commands.chart.test import test
+from zep_dev.commands.chart.version import version
 
 
 @click.group("chart", help="Helm chart lint, test, and publish commands")
@@ -17,3 +18,4 @@ chart.add_command(list_changed)
 chart.add_command(lint)
 chart.add_command(push)
 chart.add_command(test)
+chart.add_command(version)

--- a/zep-dev/tests/test_chart_version.py
+++ b/zep-dev/tests/test_chart_version.py
@@ -1,0 +1,64 @@
+from collections.abc import Callable
+from types import ModuleType
+
+import pytest
+from click.testing import CliRunner
+
+from _fake_execute import FakeExecute
+from zep_dev.cli import cli
+from zep_dev.commands.chart import version as version_module
+from zep_dev.commands.chart.version import (
+    GitDescribe,
+    parse_git_describe,
+    to_chart_version,
+)
+
+
+@pytest.mark.parametrize(
+    ("output", "description", "chart_version"),
+    [
+        (
+            "v1.37.0-5-gd95cc75\n",
+            GitDescribe(base="1.37.0", height=5, sha="d95cc75"),
+            "1.37.0-5+d95cc75",
+        ),
+        (
+            "v2.8.0-0-g2150994abcdef\n",
+            GitDescribe(base="2.8.0", height=0, sha="2150994abcdef"),
+            "2.8.0",
+        ),
+    ],
+)
+def test_parse_and_transform_git_describe(
+    output: str,
+    description: GitDescribe,
+    chart_version: str,
+) -> None:
+    parsed = parse_git_describe(output)
+
+    assert parsed == description
+    assert to_chart_version(parsed) == chart_version
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        "v2.8-17-g2150994",
+        "6.33.0-26-gd7cb808",
+    ],
+)
+def test_parse_git_describe_rejects_unexpected_output(output: str) -> None:
+    with pytest.raises(ValueError, match="unexpected git describe output"):
+        parse_git_describe(output)
+
+
+def test_version_uses_stable_release_tags(
+    fake_execute: Callable[[ModuleType], FakeExecute],
+) -> None:
+    fake = fake_execute(version_module)
+    fake.on("git", "describe", stdout="v1.37.0-5-gd95cc75\n")
+
+    result = CliRunner().invoke(cli, ["chart", "version"])
+
+    assert result.exit_code == 0
+    assert result.stdout == "1.37.0-5+d95cc75\n"


### PR DESCRIPTION
This commit implements support for generating versions in the format specified in the RFC - https://github.com/zepben/deployments/tree/main/docs/rfcs/0002-argocd-and-helm#chart-versions. This will be used in CI pipelines. It is implemented in Python because bash be nasty, and named groups are really handy.

We only accept v prefixed tags as this seems to be the official format used when cutting releases.

