### PR TITLE
Always add required dependencies on chart push

### DIFF
--- a/zep-dev/src/zep_dev/commands/chart/lint.py
+++ b/zep-dev/src/zep_dev/commands/chart/lint.py
@@ -5,7 +5,7 @@ from subprocess import CalledProcessError
 import click
 from click import ClickException
 
-from zep_dev.commands.chart.utils import execute_ct_lint
+from zep_dev.commands.chart.utils import execute_ct_lint, validate_dependencies_present
 from zep_dev.models import ChartMetadata, ChartTestingConfig
 from zep_dev.shared import ResolvedChart, execute, resolve_chart
 from zep_dev.static import CT_YAML
@@ -123,19 +123,3 @@ def execute_kubeconform(helm_args: list[str], variant: str) -> None:
         raise ClickException(
             f"kubeconform failed for {variant} with rc={e.returncode}"
         ) from e
-
-
-def validate_dependencies_present(
-    chart_metadata: ChartMetadata, ct_config: ChartTestingConfig, ct_path: Path
-) -> None:
-    # Syntax is <name>=<url>
-    chart_repos = [repo.split("=")[-1] for repo in ct_config.chart_repos]
-    for dependency in chart_metadata.dependencies:
-        # helm pulls OCI deps from the url in Chart.yaml during dependency build without helm repo add,
-        # so no need for us to validate it's existence in chart repos.
-        if dependency.repository.startswith("oci://ghcr.io"):
-            continue
-        if dependency.repository not in chart_repos:
-            raise ClickException(
-                f"{dependency.repository} not found in {ct_path}. It needs to be added under the chart_repos list, in the format <name>=<url>"
-            )

--- a/zep-dev/src/zep_dev/commands/chart/push.py
+++ b/zep-dev/src/zep_dev/commands/chart/push.py
@@ -7,8 +7,10 @@ import click
 from click import ClickException
 from pydantic import ValidationError
 
-from zep_dev.models import ChartMetadata
+from zep_dev.commands.chart.utils import validate_dependencies_present
+from zep_dev.models import ChartMetadata, ChartTestingConfig
 from zep_dev.shared import execute
+from zep_dev.static import CT_YAML
 
 REGISTRY_HOST = "ghcr.io"
 
@@ -52,6 +54,7 @@ def push(
     beta: str | None,
     fail_if_exists: bool,
 ) -> None:
+    chart = chart.resolve()
     try:
         meta = ChartMetadata.from_chart_dir(chart)
     except (ValueError, ValidationError) as e:
@@ -85,6 +88,32 @@ def push(
             raise ClickException(
                 f"exist check failed (rc={result.returncode}): {result.stderr.strip()}"
             )
+
+    # We count on our standard structure being:
+    # helm -> charts -> chart-name
+    helm_dir = chart.parent.parent
+    ct_path = helm_dir / CT_YAML
+    ct_config = ChartTestingConfig.from_chart_dir(helm_dir)
+    validate_dependencies_present(meta, ct_config, ct_path)
+
+    try:
+        for repo in ct_config.chart_repos:
+            name, url = repo.split("=", 1)
+            # OCI repos don't need to be explicitly added in the same way
+            # as HTTPS ones.
+            if url.startswith("oci://"):
+                continue
+            execute(
+                "helm",
+                "repo",
+                "add",
+                name,
+                url,
+                "--force-update",
+                capture_stdout=True,
+            )
+    except CalledProcessError as e:
+        raise _detailed_failure_for("repository setup", e) from e
 
     try:
         execute(

--- a/zep-dev/src/zep_dev/commands/chart/utils.py
+++ b/zep-dev/src/zep_dev/commands/chart/utils.py
@@ -1,6 +1,10 @@
 from importlib.resources import as_file, files
+from pathlib import Path
 from typing import Literal
 
+from click import ClickException
+
+from zep_dev.models import ChartMetadata, ChartTestingConfig
 from zep_dev.shared import CommandResult, execute
 
 
@@ -21,3 +25,20 @@ def execute_ct_lint(
             "--lint-conf",
             str(lint_config),
         )
+
+
+def validate_dependencies_present(
+    chart_metadata: ChartMetadata,
+    ct_config: ChartTestingConfig,
+    ct_path: Path,
+) -> None:
+    chart_repos = [repo.split("=")[-1] for repo in ct_config.chart_repos]
+    for dependency in chart_metadata.dependencies:
+        if dependency.repository.startswith("oci://ghcr.io"):
+            continue
+        if dependency.repository not in chart_repos:
+            raise ClickException(
+                f"{dependency.repository} not found in {ct_path}. "
+                "It needs to be added under the chart_repos list, "
+                "in the format <name>=<url>"
+            )

--- a/zep-dev/tests/conftest.py
+++ b/zep-dev/tests/conftest.py
@@ -3,9 +3,11 @@ from pathlib import Path
 from types import ModuleType
 
 import pytest
+import yaml
 
 from _fake_execute import FakeExecute
 from zep_dev import k8s_secrets
+from zep_dev.models import ChartTestingConfig
 
 
 @pytest.fixture
@@ -34,3 +36,34 @@ def helm_dir(tmp_path: Path) -> Path:
     d.mkdir()
     (d / "ct.yaml").write_text("namespace: test-ns\n")
     return d
+
+
+@pytest.fixture
+def chart_testing_config() -> ChartTestingConfig:
+    return ChartTestingConfig.model_validate(
+        {
+            "remote": "origin",
+            "target-branch": "main",
+            "chart-dirs": ["charts"],
+            "chart-repos": ["example-repo=https://example.com/helm-charts"],
+            "validate-maintainers": False,
+            "check-version-increment": False,
+            "namespace": "chart-testing",
+            "release-label": "app.kubernetes.io/instance",
+            "additional-commands": [],
+        }
+    )
+
+
+@pytest.fixture
+def write_chart_testing_config(
+    helm_dir: Path,
+) -> Callable[[ChartTestingConfig], None]:
+    def write(config: ChartTestingConfig) -> None:
+        (helm_dir / "ct.yaml").write_text(
+            yaml.safe_dump(
+                config.model_dump(by_alias=True, mode="json"), sort_keys=False
+            )
+        )
+
+    return write

--- a/zep-dev/tests/test_chart_lint.py
+++ b/zep-dev/tests/test_chart_lint.py
@@ -4,7 +4,6 @@ from types import ModuleType
 from unittest.mock import call
 
 import pytest
-import yaml
 from click.testing import CliRunner
 
 from _charts import write_chart
@@ -13,37 +12,6 @@ from zep_dev.cli import cli
 from zep_dev.commands.chart import lint as lint_module
 from zep_dev.commands.chart import utils as ct_module
 from zep_dev.models import ChartTestingConfig
-
-
-@pytest.fixture
-def chart_testing_config() -> ChartTestingConfig:
-    return ChartTestingConfig.model_validate(
-        {
-            "remote": "origin",
-            "target-branch": "main",
-            "chart-dirs": ["charts"],
-            "chart-repos": ["example-repo=https://example.com/helm-charts"],
-            "validate-maintainers": False,
-            "check-version-increment": False,
-            "namespace": "chart-testing",
-            "release-label": "app.kubernetes.io/instance",
-            "additional-commands": [],
-        }
-    )
-
-
-@pytest.fixture
-def write_chart_testing_config(
-    helm_dir: Path,
-) -> Callable[[ChartTestingConfig], None]:
-    def write(config: ChartTestingConfig) -> None:
-        (helm_dir / "ct.yaml").write_text(
-            yaml.safe_dump(
-                config.model_dump(by_alias=True, mode="json"), sort_keys=False
-            )
-        )
-
-    return write
 
 
 @pytest.fixture

--- a/zep-dev/tests/test_chart_push.py
+++ b/zep-dev/tests/test_chart_push.py
@@ -9,6 +9,72 @@ from _charts import write_chart
 from _fake_execute import FakeExecute
 from zep_dev.cli import cli
 from zep_dev.commands.chart import push as push_module
+from zep_dev.models import ChartTestingConfig
+
+
+def test_push_adds_configured_repo_before_building_dependencies(
+    helm_dir: Path,
+    auth_json: Path,
+    chart_testing_config: ChartTestingConfig,
+    write_chart_testing_config: Callable[[ChartTestingConfig], None],
+    fake_execute: Callable[[ModuleType], FakeExecute],
+) -> None:
+    repo_url = "https://grafana.github.io/helm-charts"
+    chart_testing_config.chart_repos = [f"grafana={repo_url}"]
+    write_chart_testing_config(chart_testing_config)
+    chart = write_chart(
+        helm_dir / "charts" / "alloy",
+        {
+            "name": "alloy",
+            "version": "1.2.3",
+            "dependencies": [
+                {"name": "alloy", "version": "1.0.0", "repository": repo_url}
+            ],
+        },
+    )
+    fake = (
+        fake_execute(push_module)
+        .on("helm", "repo", "add")
+        .on("helm", "dependency", "build")
+        .on("helm", "package")
+        .on("helm", "push")
+        .on("helm", "show", "chart")
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "chart",
+            "push",
+            "--chart",
+            str(chart),
+            "--registry-config",
+            str(auth_json),
+            "--oci-repo",
+            "org/repo",
+        ],
+    )
+
+    assert result.exit_code == 0
+    repo_call = call(
+        "helm",
+        "repo",
+        "add",
+        "grafana",
+        repo_url,
+        "--force-update",
+        capture_stdout=True,
+    )
+    dependency_call = call(
+        "helm",
+        "dependency",
+        "build",
+        str(chart),
+        "--registry-config",
+        str(auth_json),
+        capture_stdout=True,
+    )
+    assert fake.calls.index(repo_call) < fake.calls.index(dependency_call)
 
 
 def test_push_fail_if_exists_aborts_when_chart_present(


### PR DESCRIPTION
This was an oversight when fixing the issue with lint/test. We need to ensure that our helm repos are added locally before dependency build, otherwise it fails on CI. For test/lint, ct does this for us, but on push we need to do it.


