### PR TITLE
Support rewriting Chart metadata

### DIFF
--- a/zep-dev/src/zep_dev/commands/chart/metadata.py
+++ b/zep-dev/src/zep_dev/commands/chart/metadata.py
@@ -2,13 +2,17 @@ import json
 from pathlib import Path
 
 import click
-from click import ClickException
-from pydantic import ValidationError
 
-from zep_dev.models import ChartMetadata
+from zep_dev.commands.chart.utils import calculate_chart_version
+from zep_dev.models import ChartMetadata, ChartValues
 
 
-@click.command("metadata")
+@click.group("metadata")
+def metadata() -> None:
+    """Show or update Helm chart metadata."""
+
+
+@metadata.command("show")
 @click.option(
     "--chart",
     type=click.Path(
@@ -19,9 +23,45 @@ from zep_dev.models import ChartMetadata
     ),
     required=True,
 )
-def metadata(chart: Path) -> None:
-    try:
-        meta = ChartMetadata.from_chart_dir(chart)
-    except (ValueError, ValidationError) as e:
-        raise ClickException(str(e)) from e
+def show(chart: Path) -> None:
+    meta = ChartMetadata.from_chart_dir(chart)
     click.echo(json.dumps(meta.model_dump(mode="json")))
+
+
+@metadata.command(
+    "update",
+    help="Update Chart.yaml with calculated version, and values.yaml with --image-tag, if passed",
+)
+@click.option(
+    "--chart",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        path_type=Path,
+    ),
+    required=True,
+)
+@click.option(
+    "--image-tag",
+    default="",
+    help="Docker image tag to write to values.yaml image.tag. Can be empty, which results in values.yaml update being skipped",
+)
+def update(chart: Path, image_tag: str) -> None:
+    """Set finalized release metadata in a chart directory."""
+    chart_metadata = ChartMetadata.from_chart_dir(chart)
+    release_version = calculate_chart_version()
+
+    chart_metadata.version = release_version
+    chart_metadata.appVersion = release_version
+
+    if not image_tag.strip():
+        chart_metadata.write(chart)
+        click.echo("--image-tag empty, not updating values.yaml")
+        return
+
+    values = ChartValues.from_chart_dir(chart)
+    values.image.tag = image_tag
+
+    chart_metadata.write(chart)
+    values.write(chart)

--- a/zep-dev/src/zep_dev/commands/chart/utils.py
+++ b/zep-dev/src/zep_dev/commands/chart/utils.py
@@ -4,6 +4,11 @@ from typing import Literal
 
 from click import ClickException
 
+from zep_dev.commands.chart.version import (
+    git_describe,
+    parse_git_describe,
+    to_chart_version,
+)
 from zep_dev.models import ChartMetadata, ChartTestingConfig
 from zep_dev.shared import CommandResult, execute
 
@@ -42,3 +47,7 @@ def validate_dependencies_present(
                 "It needs to be added under the chart_repos list, "
                 "in the format <name>=<url>"
             )
+
+
+def calculate_chart_version() -> str:
+    return to_chart_version(parse_git_describe(git_describe()))

--- a/zep-dev/src/zep_dev/models.py
+++ b/zep-dev/src/zep_dev/models.py
@@ -125,7 +125,7 @@ class CiSecrets(BaseModel):
 
 
 class ChartDependency(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="allow")
 
     name: str = Field(min_length=1)
     version: str = Field(min_length=1)
@@ -133,7 +133,7 @@ class ChartDependency(BaseModel):
 
 
 class ChartMetadata(BaseModel):
-    model_config = ConfigDict(extra="ignore")
+    model_config = ConfigDict(extra="allow")
 
     name: str = Field(min_length=1)
     version: str = Field(min_length=1)
@@ -147,3 +147,35 @@ class ChartMetadata(BaseModel):
         if not chart_yaml.is_file():
             raise ValueError(f"Chart.yaml not found at {chart_yaml}")
         return cls.model_validate(yaml.safe_load(chart_yaml.read_text()))
+
+    def write(self, chart_dir: Path) -> None:
+        (chart_dir / "Chart.yaml").write_text(
+            yaml.safe_dump(
+                self.model_dump(mode="json", exclude_unset=True),
+                sort_keys=False,
+            )
+        )
+
+
+class ChartImageValues(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    tag: str | None = None
+
+
+class ChartValues(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    image: ChartImageValues = Field(default_factory=ChartImageValues)
+
+    @classmethod
+    def from_chart_dir(cls, chart_dir: Path) -> Self:
+        values_yaml = chart_dir / "values.yaml"
+        if not values_yaml.is_file():
+            return cls()
+        return cls.model_validate(yaml.safe_load(values_yaml.read_text()))
+
+    def write(self, chart_dir: Path) -> None:
+        (chart_dir / "values.yaml").write_text(
+            yaml.safe_dump(self.model_dump(mode="json"), sort_keys=False)
+        )

--- a/zep-dev/tests/test_chart_metadata.py
+++ b/zep-dev/tests/test_chart_metadata.py
@@ -1,10 +1,13 @@
 import json
 from pathlib import Path
 
+import pytest
+import yaml
 from click.testing import CliRunner
 
 from _charts import write_chart
 from zep_dev.cli import cli
+from zep_dev.commands.chart import metadata as metadata_module
 
 
 def test_metadata_full_fields(tmp_path: Path) -> None:
@@ -17,7 +20,9 @@ def test_metadata_full_fields(tmp_path: Path) -> None:
     }
     chart_dir = write_chart(tmp_path / "mychart", chart_yaml)
 
-    result = CliRunner().invoke(cli, ["chart", "metadata", "--chart", str(chart_dir)])
+    result = CliRunner().invoke(
+        cli, ["chart", "metadata", "show", "--chart", str(chart_dir)]
+    )
 
     assert result.exit_code == 0
     assert json.loads(result.stdout) == chart_yaml
@@ -26,6 +31,60 @@ def test_metadata_full_fields(tmp_path: Path) -> None:
 def test_metadata_missing_version_fails(tmp_path: Path) -> None:
     chart_dir = write_chart(tmp_path / "mychart", {"name": "mychart"})
 
-    result = CliRunner().invoke(cli, ["chart", "metadata", "--chart", str(chart_dir)])
+    result = CliRunner().invoke(
+        cli, ["chart", "metadata", "show", "--chart", str(chart_dir)]
+    )
 
     assert result.exit_code != 0
+
+
+def test_metadata_update_sets_release_and_image_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    chart_dir = write_chart(
+        tmp_path / "mychart",
+        {"apiVersion": "v2", "name": "mychart", "version": "0.0.0"},
+    )
+    (chart_dir / "values.yaml").write_text("replicas: 2\n", encoding="utf-8")
+    monkeypatch.setattr(
+        metadata_module, "calculate_chart_version", lambda: "1.2.3-4+abc1234"
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "chart",
+            "metadata",
+            "update",
+            "--chart",
+            str(chart_dir),
+            "--image-tag",
+            "sha-abc1234",
+        ],
+    )
+
+    assert result.exit_code == 0
+    chart_yaml = yaml.safe_load((chart_dir / "Chart.yaml").read_text())
+    values_yaml = yaml.safe_load((chart_dir / "values.yaml").read_text())
+    assert chart_yaml["version"] == "1.2.3-4+abc1234"
+    assert chart_yaml["appVersion"] == "1.2.3-4+abc1234"
+    assert values_yaml == {"replicas": 2, "image": {"tag": "sha-abc1234"}}
+
+
+def test_metadata_update_without_image_tag_leaves_values_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chart_dir = write_chart(
+        tmp_path / "mychart", {"name": "mychart", "version": "0.0.0"}
+    )
+    values_yaml = chart_dir / "values.yaml"
+    values_yaml.write_text("unchanged: true\n", encoding="utf-8")
+    monkeypatch.setattr(metadata_module, "calculate_chart_version", lambda: "2.0.0")
+
+    result = CliRunner().invoke(
+        cli, ["chart", "metadata", "update", "--chart", str(chart_dir)]
+    )
+
+    assert result.exit_code == 0
+    assert values_yaml.read_text(encoding="utf-8") == "unchanged: true\n"


### PR DESCRIPTION
Implement support for updating Chart.yaml such that appVersion and version both point to the same computed version described in the RFC - https://github.com/zepben/deployments/tree/main/docs/rfcs/0002-argocd-and-helm#chart-versions.
    
Additionally, if --image-tag is passed, also update the values file with the docker image tag. This ensures that the chart will pull the same image version as the commit it was built off, locking the chart and the docker image together. The advantage of doing it this way, is we don't need to specify both the docker image tag and the chart version in Argo when we add it to the deployments repo values. This also makes it clear that the two are tightly coupled.

--image-tag is not required, as not all repositories that have charts, have images. For example, helm-commons does not have any accociated Docker images.

We just modify the files in the same checkout, as on CI we later thrown this all away and it doesn't matter. Potentially we could have done all this in a temporary directry to preserve current git state. Maybe that will become an issue, and if so we will fix it then.
    
One somewhat regrettable side effect of this change is that the round trip through Pydantic/PyYaml strips comments and whitespace. The changes are not functiona; just cosmetic. As we do not save the results of this metadata update ever, I figure this is OK. If at a later stage we want to make it preserve these things we can use another library like ruamel and remove Pydantic for the values.yaml.


Signed-off-by: William Coe <william.coe@zepben.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>