### PR TITLE
Make all chart pushes idempotent

### DIFF
--- a/zep-dev/src/zep_dev/commands/chart/push.py
+++ b/zep-dev/src/zep_dev/commands/chart/push.py
@@ -1,4 +1,3 @@
-import json
 from pathlib import Path
 from subprocess import CalledProcessError
 from tempfile import TemporaryDirectory
@@ -45,14 +44,10 @@ def _detailed_failure_for(step: str, e: CalledProcessError) -> ClickException:
     required=True,
 )
 @click.option("--oci-repo", required=True, help="OCI path after host, e.g. owner/repo")
-@click.option("--beta", default=None)
-@click.option("--fail-if-exists", is_flag=True, default=False)
 def push(
     chart: Path,
     registry_config: Path,
     oci_repo: str,
-    beta: str | None,
-    fail_if_exists: bool,
 ) -> None:
     chart = chart.resolve()
     try:
@@ -60,34 +55,38 @@ def push(
     except (ValueError, ValidationError) as e:
         raise ClickException(str(e)) from e
 
-    version = f"{meta.version}-beta.{beta}" if beta is not None else meta.version
+    version = meta.version
 
     oci_base = f"oci://{REGISTRY_HOST}/{oci_repo}"
     oci_chart = f"{oci_base}/{meta.name}"
     archive_name = f"{meta.name}-{version}.tgz"
     registry_config_arg = str(registry_config)
 
-    if fail_if_exists:
-        result = execute(
-            "helm",
-            "show",
-            "chart",
-            oci_chart,
-            "--version",
-            version,
-            "--registry-config",
-            registry_config_arg,
-            check=False,
-            capture_stdout=True,
-            capture_stderr=True,
+    result = execute(
+        "helm",
+        "show",
+        "chart",
+        oci_chart,
+        "--version",
+        version,
+        "--registry-config",
+        registry_config_arg,
+        check=False,
+        capture_stdout=True,
+        capture_stderr=True,
+    )
+    if result.returncode == 0:
+        click.echo(
+            f"{meta.name}:{version} already exists in registry, skipping push",
+            err=True,
         )
-        if result.returncode == 0:
-            raise ClickException(f"{meta.name}:{version} already exists in registry")
-        text = f"{result.stderr}\n{result.stdout}".lower()
-        if "not found" not in text and "manifest unknown" not in text:
-            raise ClickException(
-                f"exist check failed (rc={result.returncode}): {result.stderr.strip()}"
-            )
+        return
+
+    text = f"{result.stderr}\n{result.stdout}".lower()
+    if "not found" not in text and "manifest unknown" not in text:
+        raise ClickException(
+            f"exist check failed (rc={result.returncode}): {result.stderr.strip()}"
+        )
 
     # We count on our standard structure being:
     # helm -> charts -> chart-name
@@ -129,17 +128,15 @@ def push(
         raise _detailed_failure_for("dependency build", e) from e
 
     with TemporaryDirectory() as tmp:
-        package_args = [
-            "helm",
-            "package",
-            str(chart),
-            "--destination",
-            tmp,
-        ]
-        if beta is not None:
-            package_args.extend(["--version", version])
         try:
-            execute(*package_args, capture_stdout=True)
+            execute(
+                "helm",
+                "package",
+                str(chart),
+                "--destination",
+                tmp,
+                capture_stdout=True,
+            )
             execute(
                 "helm",
                 "push",
@@ -149,27 +146,5 @@ def push(
                 registry_config_arg,
                 capture_stdout=True,
             )
-            execute(
-                "helm",
-                "show",
-                "chart",
-                oci_chart,
-                "--version",
-                version,
-                "--registry-config",
-                registry_config_arg,
-                capture_stdout=True,
-            )
         except CalledProcessError as e:
             raise _detailed_failure_for("push", e) from e
-
-        click.echo(
-            json.dumps(
-                {
-                    "name": meta.name,
-                    "version": version,
-                    "oci_ref": f"{REGISTRY_HOST}/{oci_repo}/{meta.name}:{version}",
-                    "archive": archive_name,
-                }
-            )
-        )

--- a/zep-dev/tests/_fake_execute.py
+++ b/zep-dev/tests/_fake_execute.py
@@ -15,11 +15,15 @@ ExecuteHook = Callable[[tuple[str, ...], dict[str, object]], None]
 class _Rule:
     prefix: tuple[str, ...]
     result: CommandResult
+    match_kwargs: dict[str, object] | None = None
     raises: BaseException | None = None
     hook: ExecuteHook | None = None
 
-    def matches(self, args: tuple[str, ...]) -> bool:
-        return args[: len(self.prefix)] == self.prefix
+    def matches(self, args: tuple[str, ...], kwargs: dict[str, object]) -> bool:
+        return args[: len(self.prefix)] == self.prefix and (
+            self.match_kwargs is None
+            or all(kwargs.get(key) == value for key, value in self.match_kwargs.items())
+        )
 
 
 @dataclass
@@ -33,6 +37,7 @@ class FakeExecute:
         stdout: str = "",
         stderr: str = "",
         returncode: int = 0,
+        match_kwargs: dict[str, object] | None = None,
         raises: BaseException | None = None,
         hook: ExecuteHook | None = None,
     ) -> FakeExecute:
@@ -40,6 +45,7 @@ class FakeExecute:
             _Rule(
                 prefix=prefix,
                 result=CommandResult(returncode, stdout, stderr),
+                match_kwargs=match_kwargs,
                 raises=raises,
                 hook=hook,
             )
@@ -52,7 +58,7 @@ class FakeExecute:
     def __call__(self, *args: str, **kwargs: object) -> CommandResult:
         self.calls.append(call(*args, **kwargs))
         for rule in self._rules:
-            if rule.matches(args):
+            if rule.matches(args, kwargs):
                 result, raises, hook = rule.result, rule.raises, rule.hook
                 break
         else:

--- a/zep-dev/tests/test_chart_push.py
+++ b/zep-dev/tests/test_chart_push.py
@@ -34,11 +34,18 @@ def test_push_adds_configured_repo_before_building_dependencies(
     )
     fake = (
         fake_execute(push_module)
+        .on(
+            "helm",
+            "show",
+            "chart",
+            returncode=1,
+            stderr="manifest unknown",
+            match_kwargs={"check": False},
+        )
         .on("helm", "repo", "add")
         .on("helm", "dependency", "build")
         .on("helm", "package")
         .on("helm", "push")
-        .on("helm", "show", "chart")
     )
 
     result = CliRunner().invoke(
@@ -77,7 +84,7 @@ def test_push_adds_configured_repo_before_building_dependencies(
     assert fake.calls.index(repo_call) < fake.calls.index(dependency_call)
 
 
-def test_push_fail_if_exists_aborts_when_chart_present(
+def test_push_is_idempotent_when_chart_present(
     tmp_path: Path, fake_execute: Callable[[ModuleType], FakeExecute]
 ) -> None:
     chart = write_chart(
@@ -101,12 +108,12 @@ def test_push_fail_if_exists_aborts_when_chart_present(
             str(auth),
             "--oci-repo",
             "org/repo",
-            "--fail-if-exists",
         ],
     )
 
-    assert result.exit_code != 0
-    assert "already exists" in result.output
+    assert result.exit_code == 0
+    assert result.stdout == ""
+    assert result.stderr == "ewb:1.2.3 already exists in registry, skipping push\n"
     assert fake.calls == [
         call(
             "helm",


### PR DESCRIPTION
Previously, we were super duper careful, and failed if the chart already
existed. This was all fine and good, but really what we care about is
that we don't modify existing artifacts that have been pushed. To
simplify all the things, just do nothing if the chart already exists.

This also drops the beta push path, as that is not used anymore. We will push to nexus instead for dev pacakges, that is just changing the destination OCI repository by command line flag.

Signed-off-by: William Coe <william.coe@zepben.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>