### PR TITLE
Add annotation based chart selection, and guards

### DIFF
--- a/zep-dev/src/zep_dev/commands/chart/list.py
+++ b/zep-dev/src/zep_dev/commands/chart/list.py
@@ -1,0 +1,66 @@
+import json
+from pathlib import Path
+
+import click
+from pydantic.dataclasses import dataclass
+
+from zep_dev.models import ChartMetadata
+
+
+@dataclass
+class KeyValue:
+    key: str
+    value: str
+
+
+def parse_key_value(
+    ctx: click.Context,
+    param: click.Parameter,
+    value: str | None,
+) -> KeyValue | None:
+    if value is None:
+        return None
+    key, sep, val = value.partition("=")
+    if not sep or not key or not val:
+        raise click.BadParameter(
+            "must be in KEY=VALUE form with a non-empty key and value",
+            ctx=ctx,
+            param=param,
+        )
+    return KeyValue(key, val)
+
+
+@click.command("list")
+@click.option(
+    "--helm-dir",
+    type=click.Path(
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
+        path_type=Path,
+    ),
+    required=True,
+)
+@click.option("--annotation", callback=parse_key_value)
+@click.option("--type", "chart_type")
+def list_charts(
+    helm_dir: Path,
+    annotation: KeyValue | None,
+    chart_type: str | None,
+) -> None:
+    """List Helm charts selected by Chart.yaml metadata."""
+
+    matches: list[str] = []
+    for chart_yaml in sorted((helm_dir / "charts").glob("*/Chart.yaml")):
+        chart_dir = chart_yaml.parent
+        metadata = ChartMetadata.from_chart_dir(chart_dir)
+        if (
+            annotation is not None
+            and metadata.annotations.get(annotation.key) != annotation.value
+        ):
+            continue
+        if chart_type is not None and metadata.type != chart_type:
+            continue
+        matches.append(str(chart_dir))
+
+    click.echo(json.dumps(matches))

--- a/zep-dev/src/zep_dev/commands/chart/metadata.py
+++ b/zep-dev/src/zep_dev/commands/chart/metadata.py
@@ -6,6 +6,10 @@ import click
 from zep_dev.commands.chart.utils import calculate_chart_version
 from zep_dev.models import ChartMetadata, ChartValues
 
+# When this annotation is present and set to true, it indicates that we
+# should process the metadata update and update the version/tag.
+PUBLISH_ANNOTATION = "zepben.com/publish-with-application-image"
+
 
 @click.group("metadata")
 def metadata() -> None:
@@ -30,7 +34,7 @@ def show(chart: Path) -> None:
 
 @metadata.command(
     "update",
-    help="Update Chart.yaml with calculated version, and values.yaml with --image-tag, if passed",
+    help="Update release metadata according to the chart annotations",
 )
 @click.option(
     "--chart",
@@ -45,23 +49,42 @@ def show(chart: Path) -> None:
 @click.option(
     "--image-tag",
     default="",
-    help="Docker image tag to write to values.yaml image.tag. Can be empty, which results in values.yaml update being skipped",
+    help="Docker image tag for charts published with the application image",
 )
 def update(chart: Path, image_tag: str) -> None:
     """Set finalized release metadata in a chart directory."""
     chart_metadata = ChartMetadata.from_chart_dir(chart)
-    release_version = calculate_chart_version()
+    publish_with_image = chart_metadata.annotations.get(PUBLISH_ANNOTATION) == "true"
+    image_tag = image_tag.strip()
 
+    values: ChartValues | None = None
+    if publish_with_image:
+        if not image_tag:
+            raise click.ClickException(
+                "--image-tag is required for charts published with the application image"
+            )
+        if chart_metadata.type != "application":
+            raise click.ClickException(
+                "charts published with the application image must have type application"
+            )
+        if not (chart / "values.yaml").is_file():
+            raise click.ClickException(
+                "values.yaml is required for charts published with the application image"
+            )
+        values = ChartValues.from_chart_dir(chart)
+        if "tag" not in values.image.model_fields_set:
+            raise click.ClickException(
+                "values.yaml must define image.tag for charts published with the application image"
+            )
+    elif image_tag:
+        raise click.ClickException(f"--image-tag requires the {PUBLISH_ANNOTATION}")
+
+    release_version = calculate_chart_version()
     chart_metadata.version = release_version
     chart_metadata.appVersion = release_version
-
-    if not image_tag.strip():
-        chart_metadata.write(chart)
-        click.echo("--image-tag empty, not updating values.yaml")
-        return
-
-    values = ChartValues.from_chart_dir(chart)
-    values.image.tag = image_tag
+    if values is not None:
+        values.image.tag = image_tag
 
     chart_metadata.write(chart)
-    values.write(chart)
+    if values is not None:
+        values.write(chart)

--- a/zep-dev/src/zep_dev/groups/chart.py
+++ b/zep-dev/src/zep_dev/groups/chart.py
@@ -1,6 +1,7 @@
 import click
 
 from zep_dev.commands.chart.lint import lint
+from zep_dev.commands.chart.list import list_charts
 from zep_dev.commands.chart.list_changed import list_changed
 from zep_dev.commands.chart.metadata import metadata
 from zep_dev.commands.chart.push import push
@@ -14,6 +15,7 @@ def chart() -> None:
 
 
 chart.add_command(metadata)
+chart.add_command(list_charts)
 chart.add_command(list_changed)
 chart.add_command(lint)
 chart.add_command(push)

--- a/zep-dev/src/zep_dev/models.py
+++ b/zep-dev/src/zep_dev/models.py
@@ -139,6 +139,7 @@ class ChartMetadata(BaseModel):
     version: str = Field(min_length=1)
     type: str = "application"
     appVersion: str | None = None
+    annotations: dict[str, str] = Field(default_factory=dict)
     dependencies: list[ChartDependency] = Field(default_factory=list)
 
     @classmethod

--- a/zep-dev/tests/test_chart_list.py
+++ b/zep-dev/tests/test_chart_list.py
@@ -1,0 +1,92 @@
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from _charts import write_chart
+from zep_dev.cli import cli
+
+
+def test_list_selects_annotated_application_charts_in_path_order(
+    helm_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    charts_dir = helm_dir / "charts"
+    annotation = {"zepben.com/publish-with-application-image": "true"}
+    write_chart(
+        charts_dir / "zebra",
+        {
+            "name": "zebra",
+            "version": "1.0.0",
+            "annotations": annotation,
+        },
+    )
+    write_chart(
+        charts_dir / "alpha",
+        {
+            "name": "alpha",
+            "version": "1.0.0",
+            "annotations": annotation,
+        },
+    )
+    write_chart(
+        charts_dir / "unannotated",
+        {"name": "unannotated", "version": "1.0.0"},
+    )
+    write_chart(
+        charts_dir / "library",
+        {
+            "name": "library",
+            "version": "1.0.0",
+            "type": "library",
+            "annotations": annotation,
+        },
+    )
+    write_chart(
+        charts_dir / "parent" / "nested",
+        {
+            "name": "nested",
+            "version": "1.0.0",
+            "annotations": annotation,
+        },
+    )
+    monkeypatch.chdir(helm_dir.parent)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "chart",
+            "list",
+            "--helm-dir",
+            "helm",
+            "--annotation",
+            "zepben.com/publish-with-application-image=true",
+            "--type",
+            "application",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.stdout) == [
+        "helm/charts/alpha",
+        "helm/charts/zebra",
+    ]
+    assert result.stderr == ""
+
+
+def test_list_rejects_invalid_annotation(helm_dir: Path) -> None:
+    result = CliRunner().invoke(
+        cli,
+        [
+            "chart",
+            "list",
+            "--helm-dir",
+            str(helm_dir),
+            "--annotation",
+            "invalid",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "--annotation" in result.stderr

--- a/zep-dev/tests/test_chart_metadata.py
+++ b/zep-dev/tests/test_chart_metadata.py
@@ -16,6 +16,7 @@ def test_metadata_full_fields(tmp_path: Path) -> None:
         "version": "1.2.3",
         "type": "library",
         "appVersion": "9.0",
+        "annotations": {"example.com/owner": "platform"},
         "dependencies": [],
     }
     chart_dir = write_chart(tmp_path / "mychart", chart_yaml)
@@ -43,9 +44,20 @@ def test_metadata_update_sets_release_and_image_metadata(
 ) -> None:
     chart_dir = write_chart(
         tmp_path / "mychart",
-        {"apiVersion": "v2", "name": "mychart", "version": "0.0.0"},
+        {
+            "apiVersion": "v2",
+            "name": "mychart",
+            "version": "0.0.0",
+            "annotations": {
+                "zepben.com/publish-with-application-image": "true",
+                "example.com/owner": "platform",
+            },
+        },
     )
-    (chart_dir / "values.yaml").write_text("replicas: 2\n", encoding="utf-8")
+    (chart_dir / "values.yaml").write_text(
+        "replicas: 2\nimage:\n  tag: old\n",
+        encoding="utf-8",
+    )
     monkeypatch.setattr(
         metadata_module, "calculate_chart_version", lambda: "1.2.3-4+abc1234"
     )
@@ -68,6 +80,10 @@ def test_metadata_update_sets_release_and_image_metadata(
     values_yaml = yaml.safe_load((chart_dir / "values.yaml").read_text())
     assert chart_yaml["version"] == "1.2.3-4+abc1234"
     assert chart_yaml["appVersion"] == "1.2.3-4+abc1234"
+    assert chart_yaml["annotations"] == {
+        "zepben.com/publish-with-application-image": "true",
+        "example.com/owner": "platform",
+    }
     assert values_yaml == {"replicas": 2, "image": {"tag": "sha-abc1234"}}
 
 
@@ -88,3 +104,82 @@ def test_metadata_update_without_image_tag_leaves_values_unchanged(
 
     assert result.exit_code == 0
     assert values_yaml.read_text(encoding="utf-8") == "unchanged: true\n"
+    assert "annotations" not in yaml.safe_load(
+        (chart_dir / "Chart.yaml").read_text(encoding="utf-8")
+    )
+
+
+def test_metadata_update_rejects_image_tag_without_annotation(tmp_path: Path) -> None:
+    chart_dir = write_chart(
+        tmp_path / "mychart",
+        {"name": "mychart", "version": "0.0.0"},
+    )
+    original_chart = (chart_dir / "Chart.yaml").read_text()
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "chart",
+            "metadata",
+            "update",
+            "--chart",
+            str(chart_dir),
+            "--image-tag",
+            "sha-abc1234",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert (chart_dir / "Chart.yaml").read_text() == original_chart
+
+
+def test_metadata_update_requires_image_tag_for_opted_in_chart(
+    tmp_path: Path,
+) -> None:
+    chart_dir = write_chart(
+        tmp_path / "mychart",
+        {
+            "name": "mychart",
+            "version": "0.0.0",
+            "annotations": {"zepben.com/publish-with-application-image": "true"},
+        },
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["chart", "metadata", "update", "--chart", str(chart_dir)],
+    )
+
+    assert result.exit_code != 0
+    assert "--image-tag is required" in result.stderr
+
+
+def test_metadata_update_requires_existing_image_tag_before_writing(
+    tmp_path: Path,
+) -> None:
+    chart_dir = write_chart(
+        tmp_path / "mychart",
+        {
+            "name": "mychart",
+            "version": "0.0.0",
+            "annotations": {"zepben.com/publish-with-application-image": "true"},
+        },
+    )
+    (chart_dir / "values.yaml").write_text("replicas: 2\n")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "chart",
+            "metadata",
+            "update",
+            "--chart",
+            str(chart_dir),
+            "--image-tag",
+            "sha-abc1234",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "must define image.tag" in result.stderr
+    assert yaml.safe_load((chart_dir / "Chart.yaml").read_text())["version"] == "0.0.0"


### PR DESCRIPTION
During our helm Application release flow, we need to do two related things: A) select the charts that we want to publish, from whatever charts exist in the chart directory, and B) update the metadata in the Chart.yaml/values.yaml. This logic should only apply to those specific Application charts that we intend to treat this way. Not all charts will want this treatment, for example, a co-located Rabbit chart in Hosting Capacity Service should not require this treatment. This would be kinda weird, but it also actually break the chart if for example the image tag was updated to our internal app one.

To handle these cases, introduce a new command "chart list", which can select only those charts with a specific annotation, for example:

	zep-dev chart list \
		--helm-dir evolve-web-app/helm/ \
		--annotation zepben.com/publish-with-application-image=true

We then check for this annotations presence in metadata update, and only apply if it is enabled. This provides some safety against accidentally targeting the wrong chart sometime.

The advantage of this approach is it makes it opt in for charts, and explicit.

Used here - https://github.com/zepben/.github/pull/119.
