### PR TITLE
Refactor repo secret handling

### DIFF
--- a/zep-dev/src/zep_dev/commands/chart/test.py
+++ b/zep-dev/src/zep_dev/commands/chart/test.py
@@ -112,12 +112,7 @@ def create_additional_secrets(namespace: str) -> None:
         config = CiSecrets.model_validate(yaml.safe_load(CI_SECRETS_YAML.read_text()))
         for secret in config.secrets:
             LOG.info("Creating additional secret: %s", secret.name)
-            secret_path = secret.resolve_path()
-            if not secret_path.is_file():
-                raise ClickException(
-                    f"Secret {secret.name}:{secret.env_var} "
-                    f"points to non-existent path: {secret_path}"
-                )
+            value = secret.resolve_value()
             if not resource_exists("secret", secret.name, namespace=namespace):
                 kubectl(
                     f"--namespace={namespace}",
@@ -125,7 +120,8 @@ def create_additional_secrets(namespace: str) -> None:
                     "secret",
                     "generic",
                     secret.name,
-                    f"--from-env-file={secret_path}",
+                    "--from-env-file=/dev/stdin",
+                    input=value,
                 )
 
 

--- a/zep-dev/src/zep_dev/models.py
+++ b/zep-dev/src/zep_dev/models.py
@@ -109,14 +109,13 @@ class CiSecret(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str
-    kind: Literal["env-file"]
     env_var: str
 
-    def resolve_path(self) -> Path:
+    def resolve_value(self) -> str:
         value = os.environ.get(self.env_var)
         if value is None:
             raise ValueError(f"{self.env_var} is not set. This is required ")
-        return Path(value).expanduser()
+        return value
 
 
 class CiSecrets(BaseModel):

--- a/zep-dev/tests/test_models.py
+++ b/zep-dev/tests/test_models.py
@@ -16,14 +16,23 @@ def tool() -> RequiredTool:
     )
 
 
-def test_ci_secret_resolve_path_missing_env_raises(
+def test_ci_secret_resolve_value_missing_env_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    secret = CiSecret(name="aws-creds", kind="env-file", env_var="AWS_CREDS_FILE")
-    monkeypatch.delenv("AWS_CREDS_FILE", raising=False)
+    secret = CiSecret(name="aws-creds", env_var="AWS_ACCESS_KEY_ID")
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
 
-    with pytest.raises(ValueError, match="AWS_CREDS_FILE is not set"):
-        secret.resolve_path()
+    with pytest.raises(ValueError, match="AWS_ACCESS_KEY_ID is not set"):
+        secret.resolve_value()
+
+
+def test_ci_secret_resolve_value_reads_environment_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = CiSecret(name="aws-creds", env_var="AWS_ACCESS_KEY_ID")
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+
+    assert secret.resolve_value() == "test-access-key"
 
 
 def test_exists_when_hash_matches(tmp_path: Path, tool: RequiredTool) -> None:


### PR DESCRIPTION
Having an env var that points to a path was convoluted. Instead, just
support defining expected env variables and we will located and load
these as k8s secrets.
