### PR TITLE
Add config_maps_from_file feature

### DIFF
--- a/zep-dev/README.md
+++ b/zep-dev/README.md
@@ -9,6 +9,25 @@ The tool requires two files:
 * kind-cluster.yaml - configures kind. See [example](examples/kind-cluster.yaml).
 * components.yaml - configures dependencies to be installed via helm when creating the kind cluster.
 
+### ConfigMaps from files
+
+A component can create ConfigMaps from files before its Helm release is installed:
+
+```yaml
+cluster_components:
+  - name: database
+    chart: example/database
+    version: "1.0.0"
+    namespace: test
+    config_maps_from_file:
+      - name: database-init
+        from_file:
+          init.sql: files/init.sql
+```
+
+Each ConfigMap uses its component namespace. On a reused Kind cluster, ConfigMaps are
+applied again before Helm is skipped. See [`examples/components.yaml`](examples/components.yaml) for an example.
+
 ## Development
 
 The Makefile in the root of the project contains some targets for interacting with the the tool. Simply run:

--- a/zep-dev/examples/components.yaml
+++ b/zep-dev/examples/components.yaml
@@ -10,6 +10,11 @@ cluster_components:
     # mounts, and that the expected env variables exist, etc.
     local_repo_integration:
       type: argo-cd
+    # Create a ConfigMap from a file relative to this components file.
+    config_maps_from_file:
+      - name: kind-cluster-config
+        from_file:
+          kind-cluster.yaml: kind-cluster.yaml
     # Complete values to be passed to helm.
     values:
       applicationSet:

--- a/zep-dev/src/zep_dev/cluster.py
+++ b/zep-dev/src/zep_dev/cluster.py
@@ -10,7 +10,7 @@ from typing import Any
 import yaml
 from click import ClickException
 
-from zep_dev.k8s import KUBECONF_PATH, kube_guard, kubectl
+from zep_dev.k8s import KUBECONF_PATH, kube_guard, kubectl, resource_exists
 from zep_dev.k8s_secrets import resolve_registry_credential
 from zep_dev.models import (
     LOCAL_REPO_MOUNT_ROOT,
@@ -273,6 +273,7 @@ def install_helm_components(
     for desired in components.cluster_components:
         reconcile_helm_component(
             desired,
+            source_dir=components.source_dir,
             installed=installed,
             local_repos_overlay=repos_overlay,
         )
@@ -281,9 +282,13 @@ def install_helm_components(
 def reconcile_helm_component(
     desired: ClusterComponent,
     *,
+    source_dir: Path | None,
     installed: Sequence[str],
     local_repos_overlay: dict[str, Any],
 ) -> None:
+    if desired.config_maps_from_file:
+        apply_configmaps_from_file(desired, source_dir)
+
     if desired.name in installed:
         LOG.info("Skipping already installed chart: %s", desired.name)
     else:
@@ -294,6 +299,24 @@ def reconcile_helm_component(
         apply_argo_oci_repository_secrets(
             desired.namespace,
             desired.local_repo_integration.oci_repositories,
+        )
+
+
+def apply_configmaps_from_file(
+    desired: ClusterComponent,
+    source_dir: Path | None,
+) -> None:
+    if not resource_exists("namespace", desired.namespace):
+        kubectl("create", "namespace", desired.namespace)
+    for config_map in desired.config_maps_from_file:
+        kubectl(
+            "apply",
+            "-f",
+            "-",
+            input=yaml.safe_dump(
+                config_map.manifest(desired.namespace, source_dir),
+                default_flow_style=False,
+            ),
         )
 
 

--- a/zep-dev/src/zep_dev/commands/cluster/create.py
+++ b/zep-dev/src/zep_dev/commands/cluster/create.py
@@ -1,4 +1,3 @@
-from io import TextIOWrapper
 from pathlib import Path
 
 import click
@@ -15,7 +14,11 @@ from zep_dev.models import LOCAL_REPO_MOUNT_ROOT, ClusterComponents
     required=True,
     help="Path to kind cluster config YAML",
 )
-@click.option("--components", type=click.File("r"), required=True)
+@click.option(
+    "--components",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    required=True,
+)
 @click.option(
     "--local-repo",
     "local_repos",
@@ -33,12 +36,12 @@ from zep_dev.models import LOCAL_REPO_MOUNT_ROOT, ClusterComponents
 )
 def create(
     kind_config: Path,
-    components: TextIOWrapper,
+    components: Path,
     local_repos: tuple[Path, ...],
 ) -> None:
     cluster.create_cluster(
         kind_config,
-        components=ClusterComponents.from_text_io(components),
+        components=ClusterComponents.from_path(components),
         local_repos=local_repos,
     )
     click.echo("Cluster created. Execute:")

--- a/zep-dev/src/zep_dev/models.py
+++ b/zep-dev/src/zep_dev/models.py
@@ -5,7 +5,8 @@ from pathlib import Path
 from typing import Any, Literal, Self, TextIO
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from click import ClickException
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 # Path inside kind workers. Argo file:// URLs and repo-server hostPath both assume it.
 LOCAL_REPO_MOUNT_ROOT = "/mnt/local-repos"
@@ -41,6 +42,29 @@ class LocalRepoIntegration(BaseModel):
     oci_repositories: list[OciRepository] = Field(default_factory=list)
 
 
+class ConfigMapFromFile(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    from_file: dict[str, str] = Field(min_length=1)
+
+    def manifest(self, namespace: str, source_dir: Path | None) -> dict[str, Any]:
+        if source_dir is None:
+            raise ClickException(
+                "config_maps_from_file requires a components file path"
+            )
+
+        return {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": self.name, "namespace": namespace},
+            "data": {
+                key: (source_dir / path).read_text(encoding="utf-8")
+                for key, path in self.from_file.items()
+            },
+        }
+
+
 class ClusterComponent(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str
@@ -48,7 +72,15 @@ class ClusterComponent(BaseModel):
     version: str
     namespace: str
     local_repo_integration: LocalRepoIntegration | None = None
+    config_maps_from_file: list[ConfigMapFromFile] = Field(default_factory=list)
     values: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_unique_config_map_names(self) -> Self:
+        names = [config_map.name for config_map in self.config_maps_from_file]
+        if len(names) != len(set(names)):
+            raise ValueError("duplicate config_maps_from_file name")
+        return self
 
 
 class RequiredTool(BaseModel):
@@ -75,11 +107,23 @@ class ClusterComponents(BaseModel):
     model_config = ConfigDict(extra="forbid")
     helm_repos: dict[str, str]
     cluster_components: list[ClusterComponent]
+    _source_dir: Path | None = PrivateAttr(default=None)
+
+    @property
+    def source_dir(self) -> Path | None:
+        return self._source_dir
 
     @classmethod
     def from_text_io(cls, input_data: TextIO) -> Self:
         data: Any = yaml.safe_load(input_data.read())
         return cls.model_validate(data)
+
+    @classmethod
+    def from_path(cls, path: Path) -> Self:
+        with path.open(encoding="utf-8") as input_data:
+            components = cls.from_text_io(input_data)
+        components._source_dir = path.parent.resolve()
+        return components
 
 
 class ChartTestingConfig(BaseModel):

--- a/zep-dev/tests/test_zep_dev.py
+++ b/zep-dev/tests/test_zep_dev.py
@@ -18,6 +18,7 @@ from zep_dev.k8s import (
 from zep_dev.models import (
     ClusterComponent,
     ClusterComponents,
+    ConfigMapFromFile,
     LocalRepo,
     LocalRepoIntegration,
     OciRepository,
@@ -40,6 +41,12 @@ def test_examples_components_yaml_parses() -> None:
     assert argo_cd.version == "9.5.0"
     assert argo_cd.namespace == "argo-cd"
     assert argo_cd.local_repo_integration == LocalRepoIntegration(type="argo-cd")
+    assert argo_cd.config_maps_from_file == [
+        ConfigMapFromFile(
+            name="kind-cluster-config",
+            from_file={"kind-cluster.yaml": "kind-cluster.yaml"},
+        )
+    ]
     assert argo_cd.values["server"]["service"]["type"] == "NodePort"
     assert argo_cd.values["configs"]["cm"]["admin.enabled"] is True
     assert argo_cd.values["dex"]["enabled"] is False
@@ -67,6 +74,149 @@ unknown_field: true
 """
     with pytest.raises(ValidationError):
         ClusterComponents.from_text_io(StringIO(yaml_input))
+
+
+def test_cluster_components_from_path_sets_source_dir(
+    tmp_path: Path,
+) -> None:
+    components_path = tmp_path / "components.yaml"
+    components_path.write_text(
+        """\
+helm_repos: {}
+cluster_components:
+  - name: database
+    chart: example/database
+    version: "1.0.0"
+    namespace: test
+    config_maps_from_file:
+      - name: database-init
+        from_file:
+          init.sql: ../sql/init.sql
+"""
+    )
+
+    from_path = ClusterComponents.from_path(components_path)
+    from_text = ClusterComponents.from_text_io(StringIO(components_path.read_text()))
+
+    assert from_path.source_dir == tmp_path.resolve()
+    assert from_text.source_dir is None
+    assert from_path.cluster_components[0].config_maps_from_file[0].from_file == {
+        "init.sql": "../sql/init.sql",
+    }
+
+
+def test_config_map_from_file_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ConfigMapFromFile.model_validate(
+            {
+                "name": "database-init",
+                "from_file": {"init.sql": "init.sql"},
+                "unexpected": True,
+            }
+        )
+
+
+def test_cluster_component_rejects_duplicate_config_map_names() -> None:
+    with pytest.raises(ValidationError, match="duplicate config_maps_from_file name"):
+        ClusterComponent.model_validate(
+            {
+                "name": "database",
+                "chart": "example/database",
+                "version": "1.0.0",
+                "namespace": "test",
+                "config_maps_from_file": [
+                    {"name": "database-init", "from_file": {"init.sql": "init.sql"}},
+                    {
+                        "name": "database-init",
+                        "from_file": {"seed.sql": "seed.sql"},
+                    },
+                ],
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    ("installed", "namespace_exists", "expected_events"),
+    [
+        ("", False, ["Namespace", "ConfigMap", "helm install"]),
+        ("database\n", False, ["Namespace", "ConfigMap"]),
+        ("", True, ["ConfigMap", "helm install"]),
+        ("database\n", True, ["ConfigMap"]),
+    ],
+)
+def test_install_helm_components_applies_config_maps_before_install_or_skip(
+    fake_execute: Callable[[ModuleType], FakeExecute],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    installed: str,
+    namespace_exists: bool,
+    expected_events: list[str],
+) -> None:
+    (tmp_path / "init.sql").write_text("SELECT 'ready';\n", encoding="utf-8")
+    components_path = tmp_path / "components.yaml"
+    components_path.write_text(
+        """\
+helm_repos: {}
+cluster_components:
+  - name: database
+    chart: example/database
+    version: "1.0.0"
+    namespace: test
+    config_maps_from_file:
+      - name: database-init
+        from_file:
+          init.sql: init.sql
+"""
+    )
+    components = ClusterComponents.from_path(components_path)
+    events: list[str] = []
+    config_maps: list[dict[str, object]] = []
+    resource_exists_calls: list[tuple[str, str]] = []
+    fake_helm = fake_execute(cluster)
+    fake_helm.on("helm", "list", stdout=installed)
+    if not installed:
+        fake_helm.on(
+            "helm",
+            "install",
+            "database",
+            hook=lambda _args, _kwargs: events.append("helm install"),
+        )
+
+    def record_create_namespace(
+        _args: tuple[str, ...], _kwargs: dict[str, object]
+    ) -> None:
+        events.append("Namespace")
+
+    def record_apply(_args: tuple[str, ...], kwargs: dict[str, object]) -> None:
+        manifest = yaml.safe_load(str(kwargs["input"]))
+        events.append(manifest["kind"])
+        if manifest["kind"] == "ConfigMap":
+            config_maps.append(manifest)
+
+    def fake_resource_exists(resource: str, name: str, **kwargs: object) -> bool:
+        resource_exists_calls.append((resource, name))
+        return namespace_exists
+
+    fake_kubectl = (
+        FakeExecute()
+        .on("create", "namespace", hook=record_create_namespace)
+        .on("apply", "-f", "-", hook=record_apply)
+    )
+    monkeypatch.setattr(cluster, "resource_exists", fake_resource_exists)
+    monkeypatch.setattr(cluster, "kubectl", fake_kubectl)
+
+    cluster.install_helm_components(components)
+
+    assert resource_exists_calls == [("namespace", "test")]
+    assert events == expected_events
+    assert config_maps == [
+        {
+            "apiVersion": "v1",
+            "kind": "ConfigMap",
+            "metadata": {"name": "database-init", "namespace": "test"},
+            "data": {"init.sql": "SELECT 'ready';\n"},
+        }
+    ]
 
 
 def test_kube_guard(


### PR DESCRIPTION
Implement support for creating a ConfigMap from a file at install time. This is to support the use case of loading the EWB init-load.sql to prepare the database and create tables etc. This is to facilitate testing EWB with and without a load DB in local kind. We want to be able to validate that our zconf auto-discovery is working, and continues to keep working.

Signed-off-by: William Coe <william.coe@zepben.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>