### PR TITLE
Support wait_for and load_db_credentials in cluster_components

### DIFF
--- a/zep-dev/README.md
+++ b/zep-dev/README.md
@@ -28,6 +28,27 @@ cluster_components:
 Each ConfigMap uses its component namespace. On a reused Kind cluster, ConfigMaps are
 applied again before Helm is skipped. See [`examples/components.yaml`](examples/components.yaml) for an example.
 
+### Waiting for resources and creating EWB load-database credentials
+
+A component can wait for resources created by its Helm chart, then create the
+Secret consumed by EWB's optional load-database configuration. This is useful for creating
+and waiting for databases to be used by EWB/HCS.
+
+```yaml
+cluster_components:
+  - name: kind-pg
+    chart: cnpg/cluster
+    version: "0.8.1"
+    namespace: ewb-test
+    wait_for:
+      - resource: cluster/kind-pg
+        for: condition=Ready
+        timeout: 180s
+    load_db_credentials:
+      from_secret: kind-pg-superuser
+      database: app
+```
+
 ## Development
 
 The Makefile in the root of the project contains some targets for interacting with the the tool. Simply run:

--- a/zep-dev/src/zep_dev/cluster.py
+++ b/zep-dev/src/zep_dev/cluster.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from base64 import b64decode
 from collections.abc import Sequence
 from contextlib import nullcontext
 from pathlib import Path
@@ -16,6 +17,7 @@ from zep_dev.models import (
     LOCAL_REPO_MOUNT_ROOT,
     ClusterComponent,
     ClusterComponents,
+    LoadDbCredentials,
     LocalRepo,
     OciRepository,
 )
@@ -295,11 +297,73 @@ def reconcile_helm_component(
         value_layers = helm_value_layers(desired, local_repos_overlay)
         install_helm_component(desired, value_layers)
 
+    wait_for_resources(desired)
+    if desired.load_db_credentials is not None:
+        apply_load_db_credentials(desired, desired.load_db_credentials)
+
     if desired.local_repo_integration:
         apply_argo_oci_repository_secrets(
             desired.namespace,
             desired.local_repo_integration.oci_repositories,
         )
+
+
+def wait_for_resources(desired: ClusterComponent) -> None:
+    for wait_for in desired.wait_for:
+        namespace = wait_for.namespace or desired.namespace
+        kubectl(
+            "wait",
+            f"--for={wait_for.for_}",
+            wait_for.resource,
+            f"--namespace={namespace}",
+            f"--timeout={wait_for.timeout}",
+        )
+
+
+def apply_load_db_credentials(
+    desired: ClusterComponent,
+    credentials: LoadDbCredentials,
+) -> None:
+    source = kubectl(
+        "get",
+        "secret",
+        credentials.from_secret,
+        f"--namespace={desired.namespace}",
+        "--output=json",
+        capture_stdout=True,
+    )
+    source_data: dict[str, str] = json.loads(source.stdout).get("data", {})
+    config = {
+        "host": secret_data(source_data, "host"),
+        "port": int(secret_data(source_data, "port")),
+        "name": credentials.database,
+        "username": secret_data(source_data, "username", "user"),
+        "password": secret_data(source_data, "password"),
+    }
+    manifest = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": "ewb-load-database-config",
+            "namespace": desired.namespace,
+        },
+        "type": "Opaque",
+        "stringData": {"load-database.json": json.dumps(config, separators=(",", ":"))},
+    }
+    kubectl(
+        "apply",
+        "-f",
+        "-",
+        input=yaml.safe_dump(manifest, default_flow_style=False),
+    )
+
+
+def secret_data(source_data: dict[str, str], *keys: str) -> str:
+    for key in keys:
+        encoded = source_data.get(key)
+        if encoded is not None:
+            return b64decode(encoded, validate=True).decode("utf-8")
+    raise ClickException(f"Secret data does not contain any of: {', '.join(keys)}")
 
 
 def apply_configmaps_from_file(

--- a/zep-dev/src/zep_dev/models.py
+++ b/zep-dev/src/zep_dev/models.py
@@ -65,6 +65,22 @@ class ConfigMapFromFile(BaseModel):
         }
 
 
+class WaitFor(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    resource: str
+    for_: str = Field(alias="for")
+    timeout: str
+    namespace: str | None = None
+
+
+class LoadDbCredentials(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    from_secret: str
+    database: str
+
+
 class ClusterComponent(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str
@@ -73,6 +89,8 @@ class ClusterComponent(BaseModel):
     namespace: str
     local_repo_integration: LocalRepoIntegration | None = None
     config_maps_from_file: list[ConfigMapFromFile] = Field(default_factory=list)
+    wait_for: list[WaitFor] = Field(default_factory=list)
+    load_db_credentials: LoadDbCredentials | None = None
     values: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")

--- a/zep-dev/tests/test_zep_dev.py
+++ b/zep-dev/tests/test_zep_dev.py
@@ -1,4 +1,6 @@
+import json
 import os
+from base64 import b64encode
 from collections.abc import Callable
 from io import StringIO
 from itertools import pairwise
@@ -7,6 +9,7 @@ from types import ModuleType
 
 import pytest
 import yaml
+from click import ClickException
 from pydantic import ValidationError
 
 from _fake_execute import FakeExecute
@@ -133,6 +136,130 @@ def test_cluster_component_rejects_duplicate_config_map_names() -> None:
                 ],
             }
         )
+
+
+def _k8s_secret_json(**fields: str) -> str:
+    return json.dumps(
+        {
+            "data": {
+                key: b64encode(value.encode()).decode() for key, value in fields.items()
+            }
+        }
+    )
+
+
+DATABASE_SUPERUSER_SECRET = _k8s_secret_json(
+    host="database-rw",
+    port="5432",
+    user="app-user",
+    password="secret-password",
+)
+
+EXPECTED_LOAD_DB_CONFIG = {
+    "host": "database-rw",
+    "port": 5432,
+    "name": "app",
+    "username": "app-user",
+    "password": "secret-password",
+}
+
+
+def test_apply_load_db_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    desired = ClusterComponent.model_validate(
+        {
+            "name": "database",
+            "chart": "example/database",
+            "version": "1.0.0",
+            "namespace": "test",
+            "load_db_credentials": {
+                "from_secret": "database-superuser",
+                "database": "app",
+            },
+        }
+    )
+    fake_kubectl = (
+        FakeExecute()
+        .on("get", "secret", "database-superuser", stdout=DATABASE_SUPERUSER_SECRET)
+        .on("apply", "-f", "-")
+    )
+    monkeypatch.setattr(cluster, "kubectl", fake_kubectl)
+
+    assert desired.load_db_credentials is not None
+    cluster.apply_load_db_credentials(desired, desired.load_db_credentials)
+
+    apply_calls = fake_kubectl.calls_for("apply", "-f", "-")
+    assert len(apply_calls) == 1
+    (apply_call,) = apply_calls
+    applied = yaml.safe_load(str(apply_call.kwargs["input"]))
+
+    string_data = applied.get("stringData")
+    assert isinstance(string_data, dict)
+    load_database_config = string_data.get("load-database.json")
+    assert isinstance(load_database_config, str)
+    assert json.loads(load_database_config) == EXPECTED_LOAD_DB_CONFIG
+
+    metadata = applied.get("metadata")
+    assert isinstance(metadata, dict)
+    assert metadata.get("name") == "ewb-load-database-config"
+    assert metadata.get("namespace") == "test"
+
+
+def test_apply_load_db_credentials_fails_when_required_secret_key_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desired = ClusterComponent.model_validate(
+        {
+            "name": "database",
+            "chart": "example/database",
+            "version": "1.0.0",
+            "namespace": "test",
+            "load_db_credentials": {
+                "from_secret": "database-superuser",
+                "database": "app",
+            },
+        }
+    )
+    fake_kubectl = FakeExecute().on(
+        "get",
+        "secret",
+        "database-superuser",
+        stdout=_k8s_secret_json(host="database-rw", port="5432", user="app-user"),
+    )
+    monkeypatch.setattr(cluster, "kubectl", fake_kubectl)
+
+    assert desired.load_db_credentials is not None
+    with pytest.raises(
+        ClickException, match="Secret data does not contain any of: password"
+    ):
+        cluster.apply_load_db_credentials(desired, desired.load_db_credentials)
+
+
+def test_apply_load_db_credentials_fails_on_invalid_base64_secret_data(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    desired = ClusterComponent.model_validate(
+        {
+            "name": "database",
+            "chart": "example/database",
+            "version": "1.0.0",
+            "namespace": "test",
+            "load_db_credentials": {
+                "from_secret": "database-superuser",
+                "database": "app",
+            },
+        }
+    )
+    fake_kubectl = FakeExecute().on(
+        "get",
+        "secret",
+        "database-superuser",
+        stdout=json.dumps({"data": {"host": "%%%INVALID%%%"}}),
+    )
+    monkeypatch.setattr(cluster, "kubectl", fake_kubectl)
+
+    assert desired.load_db_credentials is not None
+    with pytest.raises(Exception, match="Only base64 data is allowed"):
+        cluster.apply_load_db_credentials(desired, desired.load_db_credentials)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The RFC describes a dynamic configuration feature, where we can automagically configure our Applications based on what is present in the environment. The first concrete implementation of this is support for the $optionRef feature in zconf, which is supported in the EWB chart, for optionally including a load database.

In order to faciliate testing of this feature, and also to add support for future charts (such as HCS) that rely on databases, add support for a few knobs that make this easier.

wait_for: wait for a resource to become ready before contining. This is used to wait for the CNPG node to come up and be accepting connnections before proceeding with rest of the testing. This is a generic and generally useful feature.

load_db_credentials: this option supports reading the secret data produced by the CNPG chart, and creating a secret in the format we expect in the EWB chart. This simulates what the Terraform woudld create in production, and allows us to test the feature of the chart that optionally mounts the secret if it is present, and has EWB use it.

Signed-off-by: William Coe <william.coe@zepben.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>